### PR TITLE
FIX: reply 테이블 content 길이 1000자로 변경

### DIFF
--- a/ink-core/src/main/resources/config/liquibase/changelog/20230909_reply_expand.xml
+++ b/ink-core/src/main/resources/config/liquibase/changelog/20230909_reply_expand.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20230909" author="hkpark">
+        <modifyDataType tableName="reply" columnName="content" newDataType="varchar(1000)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/ink-core/src/main/resources/config/liquibase/master.xml
+++ b/ink-core/src/main/resources/config/liquibase/master.xml
@@ -18,4 +18,5 @@
     <include file="config/liquibase/changelog/20210708_today_expression.xml"/>
     <include file="config/liquibase/changelog/20230413_admin.xml"/>
     <include file="config/liquibase/changelog/20230420_admin_log.xml"/>
+    <include file="config/liquibase/changelog/20230909_reply_expand.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## 작업 내용 설명
- 답변 최대 길이 1000자로 수정

## 주요 변경 사항
- reply 테이블 content 길이 자료형 varchar(1000)으로 수정 (liquibase 수정)

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #16

@NaLDo627 @jincastle
