### PR TITLE
Feature/issue 24

### DIFF
--- a/ink-api/src/main/java/net/ink/api/member/component/MemberReportMapper.java
+++ b/ink-api/src/main/java/net/ink/api/member/component/MemberReportMapper.java
@@ -1,0 +1,21 @@
+package net.ink.api.member.component;
+
+import net.ink.api.member.dto.MemberReportDto;
+import net.ink.core.member.entity.Member;
+import net.ink.core.member.entity.MemberReport;
+import net.ink.core.reply.entity.Reply;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        imports = {Member.class})
+public interface MemberReportMapper {
+    @Mapping(target = "target", expression = "java(Member.builder().memberId(memberReportDto.getTargetId()).build())")
+    MemberReport toEntity(MemberReportDto memberReportDto);
+
+    @Mapping(target = "reporterId", expression = "java(memberReport.getReporter().getMemberId())")
+    @Mapping(target = "targetId", expression = "java(memberReport.getTarget().getMemberId())")
+    MemberReportDto.ReadOnly toDto(MemberReport memberReport);
+}

--- a/ink-api/src/main/java/net/ink/api/member/dto/MemberReportDto.java
+++ b/ink-api/src/main/java/net/ink/api/member/dto/MemberReportDto.java
@@ -1,4 +1,4 @@
-package net.ink.api.reply.dto;
+package net.ink.api.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
-import net.ink.core.reply.entity.Reply;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -18,12 +17,12 @@ import java.time.LocalDateTime;
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(value="답변 신고 모델", description="답변에 대한 신고를 나타내는 모델")
-public class ReplyReportDto {
+@ApiModel(value="회원 신고 모델", description="회원에 대한 신고를 나타내는 모델")
+public class MemberReportDto {
     @NotNull
-    @ApiModelProperty(value = "신고된 답변 ID", required = true, position = PropertyDisplayOrder.REPLY_ID)
-    @JsonProperty(index = PropertyDisplayOrder.REPLY_ID)
-    private Long replyId;
+    @ApiModelProperty(value = "신고된 회원 ID", required = true, position = PropertyDisplayOrder.TARGET_ID)
+    @JsonProperty(index = PropertyDisplayOrder.TARGET_ID)
+    private Long targetId;
 
     @NotEmpty
     @ApiModelProperty(value = "신고 사유", required = true, position = PropertyDisplayOrder.REASON)
@@ -38,8 +37,8 @@ public class ReplyReportDto {
     @Getter @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    @ApiModel(value="답변 읽기 모델", description="질문에 대한 답변을 나타내는 읽기 전용 모델")
-    public static class ReadOnly extends ReplyReportDto {
+    @ApiModel(value="회원 신고 읽기 모델", description="회원에 대한 신고를 나타내는 읽기 전용 모델")
+    public static class ReadOnly extends MemberReportDto {
         @ApiModelProperty(value = "신고 ID", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = PropertyDisplayOrder.REPORT_ID)
         @JsonProperty(index = PropertyDisplayOrder.REPORT_ID)
         private Long reportId;
@@ -52,7 +51,7 @@ public class ReplyReportDto {
 
     private static class PropertyDisplayOrder {
         private static final int REPORT_ID           = 0;
-        private static final int REPLY_ID            = 1;
+        private static final int TARGET_ID           = 1;
         private static final int REPORTER_ID         = 2;
         private static final int REASON              = 3;
         private static final int HIDE_TO_REPORTER    = 4;

--- a/ink-api/src/main/java/net/ink/api/member/web/MemberImageController.java
+++ b/ink-api/src/main/java/net/ink/api/member/web/MemberImageController.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-@Api(value = "회원 관련 엔드포인트", tags = "회원 관련 엔드포인트")
+@Api(value = "회원 이미지 엔드포인트", tags = "회원 이미지 엔드포인트")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/member")

--- a/ink-api/src/main/java/net/ink/api/member/web/MemberReplyController.java
+++ b/ink-api/src/main/java/net/ink/api/member/web/MemberReplyController.java
@@ -22,7 +22,7 @@ import springfox.documentation.annotations.ApiIgnore;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Api(value = "회원 관련 엔드포인트", tags = "회원 관련 엔드포인트")
+@Api(value = "회원 답변 엔드포인트", tags = "회원 답변 엔드포인트")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/member")

--- a/ink-api/src/main/java/net/ink/api/member/web/MemberReportController.java
+++ b/ink-api/src/main/java/net/ink/api/member/web/MemberReportController.java
@@ -1,0 +1,41 @@
+package net.ink.api.member.web;
+
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import net.ink.api.core.annotation.CurrentUser;
+import net.ink.api.core.dto.ApiResult;
+import net.ink.api.member.component.MemberReportMapper;
+import net.ink.api.member.dto.MemberReportDto;
+import net.ink.api.reply.dto.ReplyReportDto;
+import net.ink.core.member.entity.Member;
+import net.ink.core.member.entity.MemberReport;
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.member.service.MemberReportService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Api(value = "회원 신고 엔드포인트", tags = "회원 신고 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member/report")
+public class MemberReportController {
+    private final MemberReportService memberReportService;
+    private final MemberReportMapper memberReportMapper;
+
+    @ApiOperation(value = "회원 신고하기", notes = "회원을 신고합니다.")
+    @PostMapping("")
+    public ResponseEntity<ApiResult<MemberReportDto.ReadOnly>> postReportMember(@CurrentUser Member member, @RequestBody @Valid MemberReportDto memberReportDto) {
+        MemberReport memberReport = memberReportMapper.toEntity(memberReportDto);
+        memberReport.setReporter(member);
+        return ResponseEntity.ok(ApiResult.ok((memberReportMapper.toDto(
+                memberReportService.reportMember(memberReport))))
+        );
+    }
+}

--- a/ink-api/src/main/java/net/ink/api/reply/component/ReplyReportMapper.java
+++ b/ink-api/src/main/java/net/ink/api/reply/component/ReplyReportMapper.java
@@ -1,0 +1,23 @@
+package net.ink.api.reply.component;
+
+import net.ink.api.member.component.MemberMapper;
+import net.ink.api.question.component.QuestionMapper;
+import net.ink.api.reply.dto.ReplyReportDto;
+import net.ink.core.member.entity.Member;
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.entity.Reply;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        imports = {Member.class, Reply.class})
+public interface ReplyReportMapper {
+    @Mapping(target = "reply", expression = "java(Reply.builder().replyId(replyReportDto.getReplyId()).build())")
+    ReplyReport toEntity(ReplyReportDto replyReportDto);
+
+    @Mapping(target = "replyId", expression = "java(replyReport.getReply().getReplyId())")
+    @Mapping(target = "reporterId", expression = "java(replyReport.getReporter().getMemberId())")
+    ReplyReportDto.ReadOnly toDto(ReplyReport replyReport);
+}

--- a/ink-api/src/main/java/net/ink/api/reply/dto/ReplyReportDto.java
+++ b/ink-api/src/main/java/net/ink/api/reply/dto/ReplyReportDto.java
@@ -1,0 +1,60 @@
+package net.ink.api.reply.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import net.ink.core.reply.entity.Reply;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@SuperBuilder
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value="답변 신고 모델", description="답변에 대한 신고를 나타내는 모델")
+public class ReplyReportDto {
+    @NotNull
+    @ApiModelProperty(value = "신고된 답변 ID", required = true, position = PropertyDisplayOrder.REPLY_ID)
+    @JsonProperty(index = PropertyDisplayOrder.REPLY_ID)
+    private Long replyId;
+
+    @NotEmpty
+    @ApiModelProperty(value = "신고 사유", required = true, position = PropertyDisplayOrder.REASON)
+    @JsonProperty(index = PropertyDisplayOrder.REASON)
+    private String reason;
+
+    @ApiModelProperty(value = "신고자가 본인의 신고를 숨길지 여부", required = false, position = PropertyDisplayOrder.HIDE_TO_REPORTER)
+    @JsonProperty(index = PropertyDisplayOrder.HIDE_TO_REPORTER)
+    private Boolean hideToReporter = false;
+
+    @SuperBuilder
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value="답변 읽기 모델", description="질문에 대한 답변을 나타내는 읽기 전용 모델")
+    public static class ReadOnly extends ReplyReportDto {
+        @ApiModelProperty(value = "신고 ID", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = PropertyDisplayOrder.REPORT_ID)
+        @JsonProperty(index = PropertyDisplayOrder.REPORT_ID)
+        private Long reportId;
+
+        @NotNull
+        @ApiModelProperty(value = "신고자 ID", required = true, position = PropertyDisplayOrder.REPORTER_ID)
+        @JsonProperty(index = PropertyDisplayOrder.REPORTER_ID)
+        private Long reporterId;
+    }
+
+    private static class PropertyDisplayOrder {
+        private static final int REPORT_ID           = 0;
+        private static final int REPLY_ID            = 1;
+        private static final int REPORTER_ID         = 2;
+        private static final int REASON              = 3;
+        private static final int HIDE_TO_REPORTER    = 4;
+    }
+}

--- a/ink-api/src/main/java/net/ink/api/reply/service/ReplyPaginationService.java
+++ b/ink-api/src/main/java/net/ink/api/reply/service/ReplyPaginationService.java
@@ -18,7 +18,7 @@ public class ReplyPaginationService {
         if (pageRequest.getSort() == ApiPageRequest.PageSort.POPULAR)
             return replyRepository.findAllByQuestionQuestionIdOrderByReplyLikesSize(questionId, pageRequest.convert());
 
-        return replyRepository.findAllByQuestionQuestionId(questionId, pageRequest.convertWithNewestSort());
+        return replyRepository.findAllByQuestionQuestionIdAndVisible(questionId, true, pageRequest.convertWithNewestSort());
     }
 
     @Transactional(readOnly = true)
@@ -26,6 +26,6 @@ public class ReplyPaginationService {
         if (pageRequest.getSort() == ApiPageRequest.PageSort.POPULAR)
             return replyRepository.findAllByOrderByReplyLikesSize(pageRequest.convert());
 
-        return replyRepository.findAll(pageRequest.convertWithNewestSort());
+        return replyRepository.findAllByVisible(true, pageRequest.convertWithNewestSort());
     }
 }

--- a/ink-api/src/main/java/net/ink/api/reply/web/ReplyReportController.java
+++ b/ink-api/src/main/java/net/ink/api/reply/web/ReplyReportController.java
@@ -1,0 +1,49 @@
+package net.ink.api.reply.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.ink.api.core.annotation.CurrentUser;
+import net.ink.api.core.dto.ApiPageRequest;
+import net.ink.api.core.dto.ApiPageResult;
+import net.ink.api.core.dto.ApiResult;
+import net.ink.api.reply.component.ReplyMapper;
+import net.ink.api.reply.component.ReplyReportMapper;
+import net.ink.api.reply.dto.ReplyDto;
+import net.ink.api.reply.dto.ReplyReportDto;
+import net.ink.api.reply.service.ReplyPaginationService;
+import net.ink.core.badge.service.BadgeAccomplishedService;
+import net.ink.core.member.entity.Member;
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.question.entity.Question;
+import net.ink.core.reply.entity.Reply;
+import net.ink.core.reply.service.ReplyReportService;
+import net.ink.core.reply.service.ReplyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Api(value = "답변 엔드포인트", tags = "답변 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reply/report")
+public class ReplyReportController {
+    private final ReplyReportService replyReportService;
+    private final ReplyReportMapper replyReportMapper;
+
+    @ApiOperation(value = "답변 신고하기", notes = "답변을 신고합니다.")
+    @PostMapping("")
+    public ResponseEntity<ApiResult<ReplyReportDto.ReadOnly>> postReportReply(@CurrentUser Member member, @RequestBody @Valid ReplyReportDto replyReportDto) {
+        ReplyReport replyReport = replyReportMapper.toEntity(replyReportDto);
+        replyReport.setReporter(member);
+        return ResponseEntity.ok(ApiResult.ok((replyReportMapper.toDto(
+                replyReportService.reportReply(replyReport))))
+        );
+    }
+}

--- a/ink-api/src/main/java/net/ink/api/reply/web/ReplyReportController.java
+++ b/ink-api/src/main/java/net/ink/api/reply/web/ReplyReportController.java
@@ -29,7 +29,7 @@ import springfox.documentation.annotations.ApiIgnore;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-@Api(value = "답변 엔드포인트", tags = "답변 엔드포인트")
+@Api(value = "답변 신고 엔드포인트", tags = "답변 신고 엔드포인트")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reply/report")

--- a/ink-api/src/test/java/net/ink/api/common/DtoCreator.java
+++ b/ink-api/src/test/java/net/ink/api/common/DtoCreator.java
@@ -2,6 +2,7 @@ package net.ink.api.common;
 
 import net.ink.api.badge.dto.BadgeDto;
 import net.ink.api.member.dto.MemberDto;
+import net.ink.api.member.dto.MemberReportDto;
 import net.ink.api.question.dto.QuestionDto;
 import net.ink.api.question.dto.WordHintDto;
 import net.ink.api.reply.dto.ReplyDto;
@@ -102,4 +103,13 @@ public class DtoCreator {
                 .build();
     }
 
+    public static MemberReportDto.ReadOnly createMemberReportDto() {
+        return MemberReportDto.ReadOnly.builder()
+                .reportId(1L)
+                .targetId(1L)
+                .reporterId(1L)
+                .reason("Test Reason")
+                .hideToReporter(true)
+                .build();
+    }
 }

--- a/ink-api/src/test/java/net/ink/api/common/DtoCreator.java
+++ b/ink-api/src/test/java/net/ink/api/common/DtoCreator.java
@@ -6,6 +6,7 @@ import net.ink.api.question.dto.QuestionDto;
 import net.ink.api.question.dto.WordHintDto;
 import net.ink.api.reply.dto.ReplyDto;
 import net.ink.api.reply.dto.ReplyLikesDto;
+import net.ink.api.reply.dto.ReplyReportDto;
 import net.ink.api.todayexpression.dto.UsefulExpressionDto;
 import net.ink.core.member.entity.MemberSetting;
 
@@ -88,6 +89,16 @@ public class DtoCreator {
         return BadgeDto.builder()
                 .name("Badge Test")
                 .content("Badge Test Content")
+                .build();
+    }
+
+    public static ReplyReportDto.ReadOnly createReplyReportDto() {
+        return ReplyReportDto.ReadOnly.builder()
+                .reportId(1L)
+                .replyId(1L)
+                .reporterId(1L)
+                .reason("Test Reason")
+                .hideToReporter(true)
                 .build();
     }
 

--- a/ink-api/src/test/java/net/ink/api/common/DtoCreator.java
+++ b/ink-api/src/test/java/net/ink/api/common/DtoCreator.java
@@ -106,7 +106,7 @@ public class DtoCreator {
     public static MemberReportDto.ReadOnly createMemberReportDto() {
         return MemberReportDto.ReadOnly.builder()
                 .reportId(1L)
-                .targetId(1L)
+                .targetId(2L)
                 .reporterId(1L)
                 .reason("Test Reason")
                 .hideToReporter(true)

--- a/ink-api/src/test/java/net/ink/api/member/component/MemberReportMapperTest.java
+++ b/ink-api/src/test/java/net/ink/api/member/component/MemberReportMapperTest.java
@@ -1,0 +1,47 @@
+package net.ink.api.member.component;
+
+import net.ink.api.common.DtoCreator;
+import net.ink.api.member.dto.MemberReportDto;
+import net.ink.core.common.EntityCreator;
+import net.ink.core.member.entity.MemberReport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class MemberReportMapperTest {
+    @Autowired
+    MemberReportMapper memberReportMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        // given
+        MemberReport memberReport = EntityCreator.createMemberReportEntity();
+        // when
+        MemberReportDto.ReadOnly mappedDto = memberReportMapper.toDto(memberReport);
+
+        // then
+        assertNotNull(mappedDto);
+        assertEquals(memberReport.getReportId(), mappedDto.getReportId());
+        assertEquals(memberReport.getReporter().getMemberId(), mappedDto.getReporterId());
+        assertEquals(memberReport.getTarget().getMemberId(), mappedDto.getTargetId());
+        assertEquals(memberReport.getReason(), mappedDto.getReason());
+        assertEquals(memberReport.getHideToReporter(), mappedDto.getHideToReporter());
+    }
+
+    @Test
+    void DTO에서_엔티티변환_테스트() {
+        // given
+        MemberReportDto memberReportDto = DtoCreator.createMemberReportDto();
+        // when
+        MemberReport mappedEntity = memberReportMapper.toEntity(memberReportDto);
+
+        // then
+        assertNotNull(mappedEntity);
+        assertEquals(memberReportDto.getTargetId(), mappedEntity.getTarget().getMemberId());
+        assertEquals(memberReportDto.getReason(), mappedEntity.getReason());
+        assertEquals(memberReportDto.getHideToReporter(), mappedEntity.getHideToReporter());
+    }
+}

--- a/ink-api/src/test/java/net/ink/api/member/web/MemberReportControllerTest.java
+++ b/ink-api/src/test/java/net/ink/api/member/web/MemberReportControllerTest.java
@@ -37,6 +37,22 @@ class MemberReportControllerTest extends AbstractControllerTest {
 
     @Test
     @WithMockInkUser
+    @DisplayName("Should return BAD REQUEST when reporting self")
+    public void shouldReturnBadRequestWhenReportingSelf() throws Exception {
+        MemberReportDto memberReportDto = DtoCreator.createMemberReportDto();
+        memberReportDto.setTargetId(1L);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(memberReportDto);
+
+        mockMvc.perform(post("/api/member/report")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockInkUser
     @DisplayName("Should return BAD REQUEST when reporting a member fails")
     public void shouldReturnBadRequestWhenReportingReplyFails() throws Exception {
         mockMvc.perform(post("/api/member/report")

--- a/ink-api/src/test/java/net/ink/api/member/web/MemberReportControllerTest.java
+++ b/ink-api/src/test/java/net/ink/api/member/web/MemberReportControllerTest.java
@@ -1,0 +1,48 @@
+package net.ink.api.member.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.ink.api.annotation.WithMockInkUser;
+import net.ink.api.common.DtoCreator;
+import net.ink.api.member.dto.MemberReportDto;
+import net.ink.api.reply.dto.ReplyReportDto;
+import net.ink.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberReportControllerTest extends AbstractControllerTest {
+    @Test
+    @WithMockInkUser
+    @DisplayName("Should return OK when reporting a member")
+    public void shouldReturnOkWhenReportingReply() throws Exception {
+        MemberReportDto memberReportDto = DtoCreator.createMemberReportDto();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(memberReportDto);
+
+        mockMvc.perform(post("/api/member/report")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.reason").value("Test Reason"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.reporterId").value(1))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockInkUser
+    @DisplayName("Should return BAD REQUEST when reporting a member fails")
+    public void shouldReturnBadRequestWhenReportingReplyFails() throws Exception {
+        mockMvc.perform(post("/api/member/report")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+}

--- a/ink-api/src/test/java/net/ink/api/reply/component/ReplyReportMapperTest.java
+++ b/ink-api/src/test/java/net/ink/api/reply/component/ReplyReportMapperTest.java
@@ -1,0 +1,43 @@
+package net.ink.api.reply.component;
+
+import net.ink.api.common.DtoCreator;
+import net.ink.api.reply.dto.ReplyReportDto;
+import net.ink.core.common.EntityCreator;
+import net.ink.core.member.entity.ReplyReport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ReplyReportMapperTest {
+    @Autowired
+    private ReplyReportMapper replyReportMapper;
+
+    private final ReplyReport replyReport = EntityCreator.createReplyReportEntity();
+    private final ReplyReportDto replyReportDto = DtoCreator.createReplyReportDto();
+
+    @Test
+    public void 엔티티에서_DTO변환_테스트() {
+        ReplyReportDto.ReadOnly mappedDto = replyReportMapper.toDto(replyReport);
+
+        assertNotNull(mappedDto);
+        assertEquals(replyReport.getReportId(), mappedDto.getReportId());
+        assertEquals(replyReport.getReply().getReplyId(), mappedDto.getReplyId());
+        assertEquals(replyReport.getReporter().getMemberId(), mappedDto.getReporterId());
+        assertEquals(replyReport.getReason(), mappedDto.getReason());
+        assertEquals(replyReport.getHideToReporter(), mappedDto.getHideToReporter());
+    }
+
+    @Test
+    public void DTO에서_엔티티변환_테스트() {
+        ReplyReport mappedEntity = replyReportMapper.toEntity(replyReportDto);
+
+        assertNotNull(mappedEntity);
+        assertEquals(replyReportDto.getReplyId(), mappedEntity.getReply().getReplyId());
+        assertEquals(replyReportDto.getReason(), mappedEntity.getReason());
+        assertEquals(replyReportDto.getHideToReporter(), mappedEntity.getHideToReporter());
+    }
+
+}

--- a/ink-api/src/test/java/net/ink/api/reply/web/ReplyControllerFilterByReportTest.java
+++ b/ink-api/src/test/java/net/ink/api/reply/web/ReplyControllerFilterByReportTest.java
@@ -1,0 +1,44 @@
+package net.ink.api.reply.web;
+
+import net.ink.api.annotation.WithMockInkUser;
+import net.ink.api.web.AbstractControllerTest;
+import net.ink.core.reply.service.ReplyReportFilterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ReplyControllerFilterByReportTest extends AbstractControllerTest {
+    @MockBean
+    private ReplyReportFilterService replyReportFilterService;
+
+    @Test
+    @WithMockInkUser
+    public void 답변_인기순_조회_신고_필터_테스트() throws Exception {
+        when(replyReportFilterService.isReplyHideByReporter(any(), any()))
+                .thenReturn(false)
+                .thenReturn(true);
+
+        int page = 0;
+        int size = 2;
+        mockMvc.perform(
+                        get("/api/reply?page={page}&size={size}&sort=popular", page, size)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data", hasSize(1)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].replyId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("this is test reply 1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].replyLikeCount").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].question.content").value("This is test question."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].author.nickname").value("테스트유저"))
+                .andDo(print());
+    }
+}

--- a/ink-api/src/test/java/net/ink/api/reply/web/ReplyReportControllerTest.java
+++ b/ink-api/src/test/java/net/ink/api/reply/web/ReplyReportControllerTest.java
@@ -1,0 +1,49 @@
+package net.ink.api.reply.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.ink.api.annotation.WithMockInkUser;
+import net.ink.api.common.DtoCreator;
+import net.ink.api.reply.dto.ReplyReportDto;
+import net.ink.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReplyReportControllerTest extends AbstractControllerTest {
+    @Test
+    @WithMockInkUser
+    @DisplayName("Should return OK when reporting a reply")
+    public void shouldReturnOkWhenReportingReply() throws Exception {
+        ReplyReportDto replyReportDto = DtoCreator.createReplyReportDto();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(replyReportDto);
+
+        mockMvc.perform(post("/api/reply/report")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.reason").value("Test Reason"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.reporterId").value(1))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockInkUser
+    @DisplayName("Should return BAD REQUEST when reporting a reply fails")
+    public void shouldReturnBadRequestWhenReportingReplyFails() throws Exception {
+        mockMvc.perform(post("/api/reply/report")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+}

--- a/ink-core/src/main/java/net/ink/core/member/repository/MemberReportRepository.java
+++ b/ink-core/src/main/java/net/ink/core/member/repository/MemberReportRepository.java
@@ -1,8 +1,14 @@
 package net.ink.core.member.repository;
 
+import net.ink.core.member.entity.Member;
 import net.ink.core.member.entity.MemberReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MemberReportRepository extends JpaRepository<MemberReport, Long> {
     // Add any custom queries if needed
+    List<MemberReport> findByTarget(Member target);
+    boolean existsByTargetAndReporterAndHideToReporter(Member target, Member reporter, Boolean hideToReporter);
 }

--- a/ink-core/src/main/java/net/ink/core/member/service/MemberReportService.java
+++ b/ink-core/src/main/java/net/ink/core/member/service/MemberReportService.java
@@ -1,6 +1,7 @@
 package net.ink.core.member.service;
 
 import lombok.RequiredArgsConstructor;
+import net.ink.core.core.exception.BadRequestException;
 import net.ink.core.member.entity.MemberReport;
 import net.ink.core.member.repository.MemberReportRepository;
 import org.springframework.context.ApplicationEventPublisher;
@@ -14,6 +15,10 @@ public class MemberReportService {
 
     @Transactional
     public MemberReport reportMember(MemberReport memberReport) {
+        if (memberReport.getReporter().getMemberId().equals(memberReport.getTarget().getMemberId())) {
+            throw new BadRequestException("자기 자신을 신고할 수 없습니다.");
+        }
+
         return memberReportRepository.save(memberReport);
     }
 }

--- a/ink-core/src/main/java/net/ink/core/member/service/MemberReportService.java
+++ b/ink-core/src/main/java/net/ink/core/member/service/MemberReportService.java
@@ -13,7 +13,7 @@ public class MemberReportService {
     private final MemberReportRepository memberReportRepository;
 
     @Transactional
-    public void reportMember(MemberReport memberReport) {
-        memberReportRepository.save(memberReport);
+    public MemberReport reportMember(MemberReport memberReport) {
+        return memberReportRepository.save(memberReport);
     }
 }

--- a/ink-core/src/main/java/net/ink/core/member/service/MemberReportService.java
+++ b/ink-core/src/main/java/net/ink/core/member/service/MemberReportService.java
@@ -1,0 +1,19 @@
+package net.ink.core.member.service;
+
+import lombok.RequiredArgsConstructor;
+import net.ink.core.member.entity.MemberReport;
+import net.ink.core.member.repository.MemberReportRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberReportService {
+    private final MemberReportRepository memberReportRepository;
+
+    @Transactional
+    public void reportMember(MemberReport memberReport) {
+        memberReportRepository.save(memberReport);
+    }
+}

--- a/ink-core/src/main/java/net/ink/core/reply/repository/ReplyReportRepository.java
+++ b/ink-core/src/main/java/net/ink/core/reply/repository/ReplyReportRepository.java
@@ -1,8 +1,12 @@
 package net.ink.core.reply.repository;
 
 import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReplyReportRepository extends JpaRepository<ReplyReport, Long> {
-    // Add any custom queries if needed
+    List<ReplyReport> findByReply(Reply reply);
+    int countByReply(Reply reply);
 }

--- a/ink-core/src/main/java/net/ink/core/reply/repository/ReplyRepository.java
+++ b/ink-core/src/main/java/net/ink/core/reply/repository/ReplyRepository.java
@@ -11,20 +11,18 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
-    List<Reply> findAllByAuthorMemberIdOrderByReplyIdDesc(Long memberId);
-    List<Reply> findAllByQuestionQuestionId(Long questionId);
-    Page<Reply> findAllByQuestionQuestionId(Long questionId, Pageable pageable);
+    List<Reply> findAllByAuthorMemberIdAndVisibleOrderByReplyIdDesc(Long memberId, Boolean visible);
+    List<Reply> findAllByQuestionQuestionIdAndVisible(Long questionId, Boolean visible);
+    Page<Reply> findAllByQuestionQuestionIdAndVisible(Long questionId, Boolean visible, Pageable pageable);
 
-    Long countAllByAuthorMemberId(Long memberId);
-
-    @Query("Select r from Reply r where r.question.questionId = :questionId order by r.replyLikes.size desc")
+    @Query("Select r from Reply r where r.visible = true and r.question.questionId = :questionId order by r.replyLikes.size desc")
     Page<Reply> findAllByQuestionQuestionIdOrderByReplyLikesSize(Long questionId, Pageable pageable);
 
-    @Query("Select r from Reply r order by r.replyLikes.size desc")
+    @Query("Select r from Reply r where r.visible = true order by r.replyLikes.size desc")
     Page<Reply> findAllByOrderByReplyLikesSize(Pageable pageable);
 
-    boolean existsByRegDateBetweenAndAuthorMemberId(LocalDateTime startDateTime, LocalDateTime endDateTime, Long memberId);
+    boolean existsByRegDateBetweenAndAuthorMemberIdAndVisible(LocalDateTime startDateTime, LocalDateTime endDateTime, Long memberId, Boolean visible);
     boolean existsByQuestionQuestionIdAndAuthorMemberId(Long questionId, Long memberId);
-    Optional<Reply> findByAuthorMemberIdAndQuestionQuestionId(Long memberId, Long questionId);
     Optional<Reply> findByAuthorMemberIdAndQuestionQuestionIdAndVisible(Long memberId, Long questionId, Boolean visible);
+    Page<Reply> findAllByVisible(Boolean visible, Pageable pageable);
 }

--- a/ink-core/src/main/java/net/ink/core/reply/repository/ReplyRepository.java
+++ b/ink-core/src/main/java/net/ink/core/reply/repository/ReplyRepository.java
@@ -26,5 +26,5 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     boolean existsByRegDateBetweenAndAuthorMemberId(LocalDateTime startDateTime, LocalDateTime endDateTime, Long memberId);
     boolean existsByQuestionQuestionIdAndAuthorMemberId(Long questionId, Long memberId);
     Optional<Reply> findByAuthorMemberIdAndQuestionQuestionId(Long memberId, Long questionId);
-
+    Optional<Reply> findByAuthorMemberIdAndQuestionQuestionIdAndVisible(Long memberId, Long questionId, Boolean visible);
 }

--- a/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportFilterService.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportFilterService.java
@@ -1,0 +1,29 @@
+package net.ink.core.reply.service;
+
+import lombok.RequiredArgsConstructor;
+import net.ink.core.member.entity.Member;
+import net.ink.core.member.entity.MemberReport;
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.entity.Reply;
+import net.ink.core.reply.repository.ReplyReportRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyReportFilterService {
+    private final ReplyReportRepository replyReportRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isReplyHideByReporter(Reply reply, Member reporter) {
+        List<ReplyReport> replyReports = replyReportRepository.findByReply(reply);
+        for (ReplyReport replyReport : replyReports) {
+            if (replyReport.getReporter().getMemberId().equals(reporter.getMemberId()) && replyReport.getHideToReporter()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportFilterService.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportFilterService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import net.ink.core.member.entity.Member;
 import net.ink.core.member.entity.MemberReport;
 import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.member.repository.MemberReportRepository;
 import net.ink.core.reply.entity.Reply;
 import net.ink.core.reply.repository.ReplyReportRepository;
 import org.springframework.stereotype.Service;
@@ -15,15 +16,21 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReplyReportFilterService {
     private final ReplyReportRepository replyReportRepository;
+    private final MemberReportRepository memberReportRepository;
 
     @Transactional(readOnly = true)
     public boolean isReplyHideByReporter(Reply reply, Member reporter) {
+        if (memberReportRepository.existsByTargetAndReporterAndHideToReporter(reply.getAuthor(), reporter, true)) {
+            return true;
+        }
+
         List<ReplyReport> replyReports = replyReportRepository.findByReply(reply);
         for (ReplyReport replyReport : replyReports) {
             if (replyReport.getReporter().getMemberId().equals(reporter.getMemberId()) && replyReport.getHideToReporter()) {
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportService.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportService.java
@@ -17,9 +17,8 @@ public class ReplyReportService {
     private final ReplyReportRepository replyReportRepository;
 
     @Transactional
-    public void reportReply(ReplyReport replyReport) {
-        replyReportRepository.save(replyReport);
-
+    public ReplyReport reportReply(ReplyReport replyReport) {
         eventPublisher.publishEvent(new ReplyReportEvent(replyReport));
+        return replyReportRepository.save(replyReport);
     }
 }

--- a/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportService.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/ReplyReportService.java
@@ -1,0 +1,25 @@
+package net.ink.core.reply.service;
+
+import lombok.RequiredArgsConstructor;
+import net.ink.core.member.entity.MemberReport;
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.member.repository.MemberReportRepository;
+import net.ink.core.reply.repository.ReplyReportRepository;
+import net.ink.core.reply.service.event.ReplyReportEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyReportService {
+    private final ApplicationEventPublisher eventPublisher;
+    private final ReplyReportRepository replyReportRepository;
+
+    @Transactional
+    public void reportReply(ReplyReport replyReport) {
+        replyReportRepository.save(replyReport);
+
+        eventPublisher.publishEvent(new ReplyReportEvent(replyReport));
+    }
+}

--- a/ink-core/src/main/java/net/ink/core/reply/service/ReplyService.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/ReplyService.java
@@ -59,7 +59,7 @@ public class ReplyService {
         newReply.setQuestion(questionService.getQuestionById(questionId));
 
         Reply savedReply = replyRepository.saveAndFlush(newReply);
-        replyPostProcessService.postProcess(savedReply);
+        replyPostProcessService.postProcess(savedReply); // TODO 이벤트 기반으로 변경
 
         return savedReply;
     }
@@ -70,7 +70,7 @@ public class ReplyService {
 
     @Transactional(readOnly = true)
     public boolean isQuestionAlreadyReplied(Long questionId, Long authorId) {
-        return replyRepository.existsByQuestionQuestionIdAndAuthorMemberId(questionId, authorId);
+        return replyRepository.existsByQuestionQuestionIdAndAuthorMemberId(questionId, authorId); // visible 여부는 여기서는 확인하지 않는다.
     }
 
     @Transactional(readOnly = true)
@@ -78,7 +78,7 @@ public class ReplyService {
         LocalDateTime startDateTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0, 0)); // 오늘 00:00:00
         LocalDateTime endDatetime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59, 59)); //오늘 23:59:59
 
-        return replyRepository.existsByRegDateBetweenAndAuthorMemberId(startDateTime, endDatetime, memberId);
+        return replyRepository.existsByRegDateBetweenAndAuthorMemberIdAndVisible(startDateTime, endDatetime, memberId, true);
     }
 
     @Transactional
@@ -109,14 +109,14 @@ public class ReplyService {
 
     @Transactional(readOnly = true)
     public Reply findReplyByQuestionIdAndMember(Long memberId, Long questionId) {
-        return replyRepository.findByAuthorMemberIdAndQuestionQuestionId(memberId, questionId)
+        return replyRepository.findByAuthorMemberIdAndQuestionQuestionIdAndVisible(memberId, questionId, true)
                 .orElseThrow(() -> new EntityNotFoundException(NOT_EXIST_REPLY));
     }
 
     @Transactional(readOnly = true)
     public List<Reply> findRepliesByMemberId(Long memberId){
 
-        return replyRepository.findAllByAuthorMemberIdOrderByReplyIdDesc(memberId);
+        return replyRepository.findAllByAuthorMemberIdAndVisibleOrderByReplyIdDesc(memberId, true);
     }
 
     @Transactional(readOnly = true)

--- a/ink-core/src/main/java/net/ink/core/reply/service/event/ReplyReportEvent.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/event/ReplyReportEvent.java
@@ -1,0 +1,11 @@
+package net.ink.core.reply.service.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.ink.core.member.entity.ReplyReport;
+
+@AllArgsConstructor
+@Getter
+public class ReplyReportEvent {
+    private final ReplyReport replyReport;
+}

--- a/ink-core/src/main/java/net/ink/core/reply/service/event/ReplyReportEventListener.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/event/ReplyReportEventListener.java
@@ -2,11 +2,16 @@ package net.ink.core.reply.service.event;
 
 import lombok.RequiredArgsConstructor;
 import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.entity.Reply;
 import net.ink.core.reply.repository.ReplyReportRepository;
 import net.ink.core.reply.repository.ReplyRepository;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.List;
 
@@ -17,12 +22,16 @@ public class ReplyReportEventListener {
     private final ReplyReportRepository replyReportRepository;
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    // @TransactionalEventListener
     @EventListener
     public void handleReplyReportEvent(ReplyReportEvent event) {
         int count = replyReportRepository.countByReply(event.getReplyReport().getReply());
 
         if (count >= 3) {
-            replyRepository.delete(event.getReplyReport().getReply());
+            Reply reply = event.getReplyReport().getReply();
+            reply.setVisible(false);
+            replyRepository.save(reply);
         }
     }
 }

--- a/ink-core/src/main/java/net/ink/core/reply/service/event/ReplyReportEventListener.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/event/ReplyReportEventListener.java
@@ -1,0 +1,28 @@
+package net.ink.core.reply.service.event;
+
+import lombok.RequiredArgsConstructor;
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.repository.ReplyReportRepository;
+import net.ink.core.reply.repository.ReplyRepository;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReplyReportEventListener {
+    private final ReplyRepository replyRepository;
+    private final ReplyReportRepository replyReportRepository;
+
+    @Async
+    @EventListener
+    public void handleReplyReportEvent(ReplyReportEvent event) {
+        int count = replyReportRepository.countByReply(event.getReplyReport().getReply());
+
+        if (count >= 3) {
+            replyRepository.delete(event.getReplyReport().getReply());
+        }
+    }
+}

--- a/ink-core/src/test/java/net/ink/core/common/EntityCreator.java
+++ b/ink-core/src/test/java/net/ink/core/common/EntityCreator.java
@@ -12,6 +12,7 @@ import net.ink.core.reply.entity.ReplyLikes;
 import net.ink.core.reply.entity.ReplyLikesPK;
 import net.ink.core.todayexpression.entity.UsefulExpression;
 
+import java.lang.annotation.Target;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -146,10 +147,12 @@ public class EntityCreator {
     }
 
     public static MemberReport createMemberReportEntity() {
+        Member target = EntityCreator.createMemberEntity();
+        target.setMemberId(2L);
         return MemberReport.builder()
                 .reportId(1L)
                 .reporter(EntityCreator.createMemberEntity())
-                .target(EntityCreator.createMemberEntity())
+                .target(target)
                 .reason("Test Reason")
                 .hideToReporter(true)
                 .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))

--- a/ink-core/src/test/java/net/ink/core/common/EntityCreator.java
+++ b/ink-core/src/test/java/net/ink/core/common/EntityCreator.java
@@ -3,9 +3,7 @@ package net.ink.core.common;
 import net.ink.core.badge.entity.Badge;
 import net.ink.core.badge.entity.BadgeAccomplished;
 import net.ink.core.badge.entity.BadgeAccomplishedPK;
-import net.ink.core.member.entity.Member;
-import net.ink.core.member.entity.MemberScrap;
-import net.ink.core.member.entity.MemberScrapPK;
+import net.ink.core.member.entity.*;
 import net.ink.core.member.entity.ReplyReport;
 import net.ink.core.question.entity.Question;
 import net.ink.core.question.entity.WordHint;
@@ -141,6 +139,17 @@ public class EntityCreator {
                 .reportId(1L)
                 .reply(EntityCreator.createReplyEntity())
                 .reporter(EntityCreator.createMemberEntity())
+                .reason("Test Reason")
+                .hideToReporter(true)
+                .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))
+                .build();
+    }
+
+    public static MemberReport createMemberReportEntity() {
+        return MemberReport.builder()
+                .reportId(1L)
+                .reporter(EntityCreator.createMemberEntity())
+                .target(EntityCreator.createMemberEntity())
                 .reason("Test Reason")
                 .hideToReporter(true)
                 .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))

--- a/ink-core/src/test/java/net/ink/core/common/EntityCreator.java
+++ b/ink-core/src/test/java/net/ink/core/common/EntityCreator.java
@@ -6,6 +6,7 @@ import net.ink.core.badge.entity.BadgeAccomplishedPK;
 import net.ink.core.member.entity.Member;
 import net.ink.core.member.entity.MemberScrap;
 import net.ink.core.member.entity.MemberScrapPK;
+import net.ink.core.member.entity.ReplyReport;
 import net.ink.core.question.entity.Question;
 import net.ink.core.question.entity.WordHint;
 import net.ink.core.reply.entity.Reply;
@@ -132,6 +133,17 @@ public class EntityCreator {
                 .id(new BadgeAccomplishedPK(1L, 1L))
                 .member(EntityCreator.createMemberEntity())
                 .badge(EntityCreator.createBadgeEntity())
+                .build();
+    }
+
+    public static ReplyReport createReplyReportEntity() {
+        return ReplyReport.builder()
+                .reportId(1L)
+                .reply(EntityCreator.createReplyEntity())
+                .reporter(EntityCreator.createMemberEntity())
+                .reason("Test Reason")
+                .hideToReporter(true)
+                .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))
                 .build();
     }
 }

--- a/ink-core/src/test/java/net/ink/core/member/repository/MemberReportRepositoryTest.java
+++ b/ink-core/src/test/java/net/ink/core/member/repository/MemberReportRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -53,5 +54,16 @@ public class MemberReportRepositoryTest {
     public void 멤버_리포트_삭제_테스트() {
         memberReportRepository.deleteById(1L);
         memberReportRepository.flush();
+    }
+    @Test
+    public void 멤버_리포트_신고자_조회_테스트() {
+        assertTrue(memberReportRepository.existsByTargetAndReporterAndHideToReporter(
+                Member.builder().memberId(1L).build(), Member.builder().memberId(2L).build(), true));
+
+        assertFalse(memberReportRepository.existsByTargetAndReporterAndHideToReporter(
+                Member.builder().memberId(1L).build(), Member.builder().memberId(2L).build(), false));
+
+        assertFalse(memberReportRepository.existsByTargetAndReporterAndHideToReporter(
+                Member.builder().memberId(1L).build(), Member.builder().memberId(5L).build(), true));
     }
 }

--- a/ink-core/src/test/java/net/ink/core/reply/repository/ReplyReportRepositoryTest.java
+++ b/ink-core/src/test/java/net/ink/core/reply/repository/ReplyReportRepositoryTest.java
@@ -57,4 +57,23 @@ public class ReplyReportRepositoryTest {
         replyReportRepository.deleteById(1L);
         replyReportRepository.flush();
     }
+
+    @Test
+    public void 댓글로_연관_리포트_조회_테스트() {
+        Reply reply = Reply.builder().replyId(1L).build();
+        ReplyReport replyReport = replyReportRepository.findByReply(reply).get(0);
+
+        assertEquals(1L, replyReport.getReportId());
+        assertEquals(1L, replyReport.getReporter().getMemberId());
+        assertEquals("Reason 1", replyReport.getReason());
+        assertTrue(replyReport.getHideToReporter());
+    }
+
+    @Test
+    public void 댓글로_연관_리포트_count_조회_테스트() {
+        Reply reply = Reply.builder().replyId(1L).build();
+        int count = replyReportRepository.countByReply(reply);
+
+        assertEquals(1, count);
+    }
 }

--- a/ink-core/src/test/java/net/ink/core/reply/repository/ReplyRepositoryTest.java
+++ b/ink-core/src/test/java/net/ink/core/reply/repository/ReplyRepositoryTest.java
@@ -36,7 +36,7 @@ public class ReplyRepositoryTest {
 
     @Test
     public void 멤버_답변_목록_조회_내림차순(){
-        List<Reply> replyList = replyRepository.findAllByAuthorMemberIdOrderByReplyIdDesc(MEMBER_ID);
+        List<Reply> replyList = replyRepository.findAllByAuthorMemberIdAndVisibleOrderByReplyIdDesc(MEMBER_ID, true);
 
         assertEquals(2, replyList.size());
 
@@ -51,7 +51,7 @@ public class ReplyRepositoryTest {
 
     @Test
     public void 질문_답변_목록_조회(){
-        List<Reply> replyList = replyRepository.findAllByQuestionQuestionId(QUESTION_ID);
+        List<Reply> replyList = replyRepository.findAllByQuestionQuestionIdAndVisible(QUESTION_ID, true);
 
         assertEquals(3, replyList.size());
 
@@ -66,8 +66,8 @@ public class ReplyRepositoryTest {
 
     @Test
     public void 질문_답변_목록_조회_페이징(){
-        List<Reply> replyList = replyRepository.findAllByQuestionQuestionId(
-                QUESTION_ID, PageRequest.of(0, 1)).getContent();
+        List<Reply> replyList = replyRepository.findAllByQuestionQuestionIdAndVisible(
+                QUESTION_ID, true, PageRequest.of(0, 1)).getContent();
 
         assertEquals(1, replyList.size());
 
@@ -86,8 +86,8 @@ public class ReplyRepositoryTest {
         LocalDateTime startDateTime2 = LocalDateTime.of(date2, LocalTime.of(0,0,0));
         LocalDateTime endDateTime2 = LocalDateTime.of(date2, LocalTime.of(23,59,59));
 
-        boolean isExist = replyRepository.existsByRegDateBetweenAndAuthorMemberId(startDateTime, endDateTime, MEMBER_ID);
-        boolean isExist2 = replyRepository.existsByRegDateBetweenAndAuthorMemberId(startDateTime2, endDateTime2, MEMBER_ID);
+        boolean isExist = replyRepository.existsByRegDateBetweenAndAuthorMemberIdAndVisible(startDateTime, endDateTime, MEMBER_ID, true);
+        boolean isExist2 = replyRepository.existsByRegDateBetweenAndAuthorMemberIdAndVisible(startDateTime2, endDateTime2, MEMBER_ID, true);
 
         assertTrue(isExist);
         assertFalse(isExist2);
@@ -95,7 +95,7 @@ public class ReplyRepositoryTest {
 
     @Test
     public void 멤버와_질문으로_답변_찾기_테스트() {
-        Reply oldReply = replyRepository.findByAuthorMemberIdAndQuestionQuestionId(MEMBER_ID, QUESTION_ID).orElseThrow();
+        Reply oldReply = replyRepository.findByAuthorMemberIdAndQuestionQuestionIdAndVisible(MEMBER_ID, QUESTION_ID, true).orElseThrow();
 
         assertEquals(REPLY_ID, oldReply.getReplyId());
         assertEquals(MEMBER_ID, oldReply.getAuthor().getMemberId());
@@ -113,7 +113,7 @@ public class ReplyRepositoryTest {
 
     @Test
     public void 질문_연관_답변_조회_최신순_테스트() {
-        List<Reply> replies = replyRepository.findAllByQuestionQuestionId(QUESTION_ID, PageRequest.of(0,
+        List<Reply> replies = replyRepository.findAllByQuestionQuestionIdAndVisible(QUESTION_ID, true, PageRequest.of(0,
                 2, Sort.by(Sort.Direction.DESC, "regDate"))).getContent();
 
         assertEquals(2, replies.size());
@@ -141,5 +141,17 @@ public class ReplyRepositoryTest {
         reply.setReplyId(null);
 
         assertThrows(DataIntegrityViolationException.class, () -> replyRepository.saveAndFlush(reply));
+    }
+
+    @Test
+    public void 질문_인기순_조회_테스트() {
+        Page<Reply> replies = replyRepository.findAllByOrderByReplyLikesSize(PageRequest.of(0, 2));
+
+        assertEquals(2, replies.getNumberOfElements());
+        assertEquals(5, replies.getTotalElements());
+        assertEquals(3, replies.getTotalPages());
+        assertEquals(2, replies.getContent().size());
+        assertEquals(2, replies.getContent().get(0).getReplyLikes().size());
+        assertEquals(0, replies.getContent().get(1).getReplyLikes().size());
     }
 }

--- a/ink-core/src/test/java/net/ink/core/reply/service/ReplyReportFilterServiceTest.java
+++ b/ink-core/src/test/java/net/ink/core/reply/service/ReplyReportFilterServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import net.ink.core.common.EntityCreator;
 import net.ink.core.member.entity.Member;
 import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.member.repository.MemberReportRepository;
 import net.ink.core.reply.entity.Reply;
 import net.ink.core.reply.repository.ReplyReportRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,6 +30,9 @@ class ReplyReportFilterServiceTest {
 
     @Mock
     private ReplyReportRepository replyReportRepository;
+
+    @Mock
+    private MemberReportRepository memberReportRepository;
 
     @InjectMocks
     private ReplyReportFilterService replyReportFilterService;
@@ -39,6 +44,7 @@ class ReplyReportFilterServiceTest {
     @Test
     @DisplayName("Should return true when reply is hidden by reporter")
     void shouldReturnTrueWhenReplyIsHiddenByReporter() {
+        when(memberReportRepository.existsByTargetAndReporterAndHideToReporter(any(), any(), any())).thenReturn(false);
         when(replyReportRepository.findByReply(reply)).thenReturn(Collections.singletonList(replyReport));
 
         assertTrue(replyReportFilterService.isReplyHideByReporter(reply, reporter));
@@ -48,14 +54,25 @@ class ReplyReportFilterServiceTest {
     @DisplayName("Should return false when reply is not hidden by reporter")
     void shouldReturnFalseWhenReplyIsNotHiddenByReporter() {
         replyReport.setHideToReporter(false);
+        when(memberReportRepository.existsByTargetAndReporterAndHideToReporter(any(), any(), any())).thenReturn(false);
         when(replyReportRepository.findByReply(reply)).thenReturn(Collections.singletonList(replyReport));
 
         assertFalse(replyReportFilterService.isReplyHideByReporter(reply, reporter));
     }
 
     @Test
+    @DisplayName("Should return true when author was reported for reply")
+    void shouldReturnTrueWhenAuthorWasReportedForReply() {
+        replyReport.setHideToReporter(false);
+        when(memberReportRepository.existsByTargetAndReporterAndHideToReporter(any(), any(), any())).thenReturn(true);
+
+        assertTrue(replyReportFilterService.isReplyHideByReporter(reply, reporter));
+    }
+
+    @Test
     @DisplayName("Should return false when no reports found for reply")
     void shouldReturnFalseWhenNoReportsFoundForReply() {
+        when(memberReportRepository.existsByTargetAndReporterAndHideToReporter(any(), any(), any())).thenReturn(false);
         when(replyReportRepository.findByReply(reply)).thenReturn(Collections.emptyList());
 
         assertFalse(replyReportFilterService.isReplyHideByReporter(reply, reporter));

--- a/ink-core/src/test/java/net/ink/core/reply/service/ReplyReportFilterServiceTest.java
+++ b/ink-core/src/test/java/net/ink/core/reply/service/ReplyReportFilterServiceTest.java
@@ -1,0 +1,63 @@
+package net.ink.core.reply.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import net.ink.core.common.EntityCreator;
+import net.ink.core.member.entity.Member;
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.entity.Reply;
+import net.ink.core.reply.repository.ReplyReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReplyReportFilterServiceTest {
+
+    @Mock
+    private ReplyReportRepository replyReportRepository;
+
+    @InjectMocks
+    private ReplyReportFilterService replyReportFilterService;
+
+    private final Reply reply = EntityCreator.createReplyEntity();
+    private final Member reporter = EntityCreator.createMemberEntity();
+    private final ReplyReport replyReport = EntityCreator.createReplyReportEntity();
+
+    @Test
+    @DisplayName("Should return true when reply is hidden by reporter")
+    void shouldReturnTrueWhenReplyIsHiddenByReporter() {
+        when(replyReportRepository.findByReply(reply)).thenReturn(Collections.singletonList(replyReport));
+
+        assertTrue(replyReportFilterService.isReplyHideByReporter(reply, reporter));
+    }
+
+    @Test
+    @DisplayName("Should return false when reply is not hidden by reporter")
+    void shouldReturnFalseWhenReplyIsNotHiddenByReporter() {
+        replyReport.setHideToReporter(false);
+        when(replyReportRepository.findByReply(reply)).thenReturn(Collections.singletonList(replyReport));
+
+        assertFalse(replyReportFilterService.isReplyHideByReporter(reply, reporter));
+    }
+
+    @Test
+    @DisplayName("Should return false when no reports found for reply")
+    void shouldReturnFalseWhenNoReportsFoundForReply() {
+        when(replyReportRepository.findByReply(reply)).thenReturn(Collections.emptyList());
+
+        assertFalse(replyReportFilterService.isReplyHideByReporter(reply, reporter));
+    }
+}

--- a/ink-core/src/test/java/net/ink/core/reply/service/ReplyReportServiceTest.java
+++ b/ink-core/src/test/java/net/ink/core/reply/service/ReplyReportServiceTest.java
@@ -1,0 +1,66 @@
+package net.ink.core.reply.service;
+
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.entity.Reply;
+import net.ink.core.reply.repository.ReplyReportRepository;
+import net.ink.core.reply.repository.ReplyRepository;
+import net.ink.core.reply.service.event.ReplyReportEvent;
+import net.ink.core.reply.service.event.ReplyReportEventListener;
+import net.ink.push.service.FcmLikePushServiceImpl;
+import net.ink.push.service.FcmService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import({FcmLikePushServiceImpl.class, FcmService.class})
+class ReplyReportServiceTest {
+    @MockBean
+    private ReplyRepository replyRepository;
+
+    @MockBean
+    private ReplyReportRepository replyReportRepository;
+
+    @Autowired
+    private ReplyReportService replyReportService;
+
+    @Test
+    public void 답변_신고_테스트() {
+        // Given
+        Reply reply = new Reply();
+        ReplyReport replyReport = new ReplyReport();
+        replyReport.setReply(reply);
+
+        when(replyReportRepository.countByReply(any(Reply.class))).thenReturn(2);
+
+        // When
+        replyReportService.reportReply(replyReport);
+
+        // Then
+        verify(replyRepository, times(0)).save(any(Reply.class));
+        verify(replyReportRepository, times(1)).save(any(ReplyReport.class));
+    }
+
+    @Test
+    public void 답변_신고_3회누적_삭제처리_테스트() {
+        // Given
+        Reply reply = new Reply();
+        ReplyReport replyReport = new ReplyReport();
+        replyReport.setReply(reply);
+
+        when(replyReportRepository.countByReply(any(Reply.class))).thenReturn(3);
+
+        // When
+        replyReportService.reportReply(replyReport);
+
+        // Then
+        verify(replyRepository, times(1)).save(any(Reply.class));
+        verify(replyReportRepository, times(1)).save(any(ReplyReport.class));
+    }
+}

--- a/ink-core/src/test/java/net/ink/core/reply/service/ReplyServiceTest.java
+++ b/ink-core/src/test/java/net/ink/core/reply/service/ReplyServiceTest.java
@@ -55,7 +55,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(notRepliedMemberId))).willReturn(false);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberIdAndVisible(any(), any(), eq(notRepliedMemberId), any())).willReturn(false);
             given(questionService.existsById(eq(QUESTION_ID))).willReturn(true);
             given(replyService.isQuestionAlreadyReplied(eq(QUESTION_ID), eq(notRepliedMemberId))).willReturn(false);
             given(questionService.getQuestionById(eq(QUESTION_ID))).willReturn(newReply.getQuestion());
@@ -79,7 +79,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(repliedMemberId))).willReturn(true);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberIdAndVisible(any(), any(), eq(repliedMemberId), any())).willReturn(true);
 
             // when
             BadRequestException exception =  assertThrows(BadRequestException.class, () -> replyService.create(newReply));
@@ -96,7 +96,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(notRepliedMemberId))).willReturn(false);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberIdAndVisible(any(), any(), eq(notRepliedMemberId), any())).willReturn(false);
             given(questionService.existsById(eq(QUESTION_ID))).willReturn(false);
 
             // when
@@ -114,7 +114,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(MEMBER_ID))).willReturn(false);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberIdAndVisible(any(), any(), eq(MEMBER_ID), any())).willReturn(false);
             given(questionService.existsById(eq(QUESTION_ID))).willReturn(true);
             given(replyService.isQuestionAlreadyReplied(eq(QUESTION_ID), eq(repliedMemberId))).willReturn(true);
 

--- a/ink-core/src/test/java/net/ink/core/reply/service/event/ReplyReportEventListenerTest.java
+++ b/ink-core/src/test/java/net/ink/core/reply/service/event/ReplyReportEventListenerTest.java
@@ -1,0 +1,59 @@
+package net.ink.core.reply.service.event;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import net.ink.core.member.entity.ReplyReport;
+import net.ink.core.reply.entity.Reply;
+import net.ink.core.reply.repository.ReplyReportRepository;
+import net.ink.core.reply.repository.ReplyRepository;
+import net.ink.push.service.FcmLikePushServiceImpl;
+import net.ink.push.service.FcmService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import({FcmLikePushServiceImpl.class, FcmService.class})
+public class ReplyReportEventListenerTest {
+
+    @MockBean
+    private ReplyRepository replyRepository;
+
+    @MockBean
+    private ReplyReportRepository replyReportRepository;
+
+    @Autowired
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    public void handleReplyReportEventTest() throws InterruptedException {
+        // Given
+        Reply reply = new Reply();
+        ReplyReport replyReport = new ReplyReport();
+        replyReport.setReply(reply);
+        ReplyReportEvent event = new ReplyReportEvent(replyReport);
+
+        when(replyReportRepository.countByReply(any(Reply.class))).thenReturn(3);
+
+        // When
+        applicationEventPublisher.publishEvent(event);
+
+        // Then
+        verify(replyRepository, times(1)).save(any(Reply.class));
+    }
+}


### PR DESCRIPTION
## 작업 내용 설명
- 신고 기능 추가에 따른 API 엔드포인트 추가 및 비즈니스 로직 추가/수정

## 주요 변경 사항
- 신고 접수 서비스 작성, 테스트 작성
   - 신고 접수시 게시물 자동 삭제 이벤트 발생 -> 수신 이벤트에서는 해당 게시물의 누적 신고를 조회해서 삭제 처리
- 신고 접수 API 작성, 테스트 작성
-  기존 조회 로직 수정
   - 사용자 로그인 후 -> 사용자 작성 질문 및 응답 조회 시
     - 신고한 사용자인 경우 응답 모두 안보여야 함 (질문 노출 여부는 추후 논의)
     - 신고한 게시물인 경우 해당 게시물 안보여야 함

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #24

@NaLDo627 @jincastle
