### PR TITLE
Refactor: AdminMember 엔티티의 rank 속성 이름 변경 및 관련 코드 수정

### DIFF
--- a/ink-admin/src/main/java/net/ink/admin/config/AdminAuthenticationSuccessHandler.java
+++ b/ink-admin/src/main/java/net/ink/admin/config/AdminAuthenticationSuccessHandler.java
@@ -19,12 +19,12 @@ public class AdminAuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
+            Authentication authentication) throws IOException, ServletException {
         // Get the authenticated user
         AdminUser user = (AdminUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
         // Check if the user's rank is PENDING
-        if (user.getRank() == AdminMember.RANK.PENDING) {
+        if (user.getAdminRank() == AdminMember.RANK.PENDING) {
             // Redirect to a specific page for PENDING users
             getRedirectStrategy().sendRedirect(request, response, "/login?pending");
             return;

--- a/ink-admin/src/main/java/net/ink/admin/dto/AdminUser.java
+++ b/ink-admin/src/main/java/net/ink/admin/dto/AdminUser.java
@@ -1,19 +1,21 @@
 package net.ink.admin.dto;
 
-import lombok.Getter;
-import lombok.Setter;
-import net.ink.admin.entity.AdminMember;
+import java.util.Collection;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
-import java.util.Collection;
+import lombok.Getter;
+import lombok.Setter;
+import net.ink.admin.entity.AdminMember;
 
-@Getter @Setter
+@Getter
+@Setter
 public class AdminUser extends User {
     private AdminMember adminMember;
 
-    public AdminMember.RANK getRank() {
-        return adminMember.getRank();
+    public AdminMember.RANK getAdminRank() {
+        return adminMember.getAdminRank();
     }
 
     public AdminUser(AdminMember adminMember, Collection<? extends GrantedAuthority> authorities) {
@@ -25,7 +27,9 @@ public class AdminUser extends User {
         super(username, password, authorities);
     }
 
-    public AdminUser(String username, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked, Collection<? extends GrantedAuthority> authorities) {
+    public AdminUser(String username, String password, boolean enabled, boolean accountNonExpired,
+            boolean credentialsNonExpired, boolean accountNonLocked,
+            Collection<? extends GrantedAuthority> authorities) {
         super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
     }
 }

--- a/ink-admin/src/main/java/net/ink/admin/entity/AdminMember.java
+++ b/ink-admin/src/main/java/net/ink/admin/entity/AdminMember.java
@@ -48,9 +48,9 @@ public class AdminMember {
     private String nickname;
 
     @Builder.Default
-    @Column(nullable = false, name = "`rank`")
+    @Column(nullable = false, name = "admin_rank")
     @Enumerated(EnumType.STRING)
-    private RANK rank = RANK.PENDING;
+    private RANK adminRank = RANK.PENDING;
 
     @Builder.Default
     @Column(name = "is_active", nullable = false)

--- a/ink-admin/src/main/java/net/ink/admin/repository/AdminMemberRepository.java
+++ b/ink-admin/src/main/java/net/ink/admin/repository/AdminMemberRepository.java
@@ -1,13 +1,17 @@
 package net.ink.admin.repository;
 
-import net.ink.admin.entity.AdminMember;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import net.ink.admin.entity.AdminMember;
 
 public interface AdminMemberRepository extends JpaRepository<AdminMember, Long> {
     Optional<AdminMember> findByEmail(String email);
-    Optional<AdminMember> findByEmailAndRankNot(String email, AdminMember.RANK rank);
+
+    Optional<AdminMember> findByEmailAndAdminRankNot(String email, AdminMember.RANK rank);
+
     boolean existsByEmailAndIsActive(String username, Boolean active);
+
     boolean existsByNicknameAndIsActive(String nickname, Boolean active);
 }

--- a/ink-admin/src/main/java/net/ink/admin/service/AdminMemberService.java
+++ b/ink-admin/src/main/java/net/ink/admin/service/AdminMemberService.java
@@ -43,11 +43,13 @@ public class AdminMemberService {
     public boolean isEmailDuplicated(String email) {
         return adminMemberRepository.existsByEmailAndIsActive(email, true);
     }
+
     @Transactional
     public void deleteAdminMemberById(Long adminId) {
-        AdminMember adminMember = adminMemberRepository.findById(adminId).orElseThrow(() -> new EntityNotFoundException(NOT_EXIST_MEMBER));
+        AdminMember adminMember = adminMemberRepository.findById(adminId)
+                .orElseThrow(() -> new EntityNotFoundException(NOT_EXIST_MEMBER));
 
-        if (adminMember.getRank() == AdminMember.RANK.SUPERVISOR) {
+        if (adminMember.getAdminRank() == AdminMember.RANK.SUPERVISOR) {
             throw new BadRequestException("슈퍼바이저는 삭제할 수 없습니다.");
         }
 
@@ -63,21 +65,22 @@ public class AdminMemberService {
         String emailSubject = "";
         String emailContent = "";
 
-        if (adminMember.getRank() == AdminMember.RANK.PENDING) {
-            adminMember.setRank(AdminMember.RANK.MANAGER);
+        if (adminMember.getAdminRank() == AdminMember.RANK.PENDING) {
+            adminMember.setAdminRank(AdminMember.RANK.MANAGER);
             sendEmail = true;
             emailSubject = "승급 안내";
             emailContent = "축하합니다! 매니저로 승급되셨습니다.";
-        } else if (adminMember.getRank() == AdminMember.RANK.MANAGER) {
-            adminMember.setRank(AdminMember.RANK.SUPERVISOR);
+        } else if (adminMember.getAdminRank() == AdminMember.RANK.MANAGER) {
+            adminMember.setAdminRank(AdminMember.RANK.SUPERVISOR);
             sendEmail = true;
             emailSubject = "승급 안내";
             emailContent = "축하합니다! 슈퍼바이저로 승급되셨습니다.";
 
-            AdminMember currentMember = ((AdminUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getAdminMember();
+            AdminMember currentMember = ((AdminUser) SecurityContextHolder.getContext().getAuthentication()
+                    .getPrincipal()).getAdminMember();
             currentMember = adminMemberRepository.findById(currentMember.getAdminId())
                     .orElseThrow(() -> new EntityNotFoundException(NOT_EXIST_MEMBER));
-            currentMember.setRank(AdminMember.RANK.MANAGER);
+            currentMember.setAdminRank(AdminMember.RANK.MANAGER);
 
             SecurityContextHolder.clearContext();
         }

--- a/ink-admin/src/main/java/net/ink/admin/service/AdminUserDetailsService.java
+++ b/ink-admin/src/main/java/net/ink/admin/service/AdminUserDetailsService.java
@@ -1,9 +1,8 @@
 package net.ink.admin.service;
 
-import lombok.RequiredArgsConstructor;
-import net.ink.admin.dto.AdminUser;
-import net.ink.admin.entity.AdminMember;
-import net.ink.admin.repository.AdminMemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,8 +10,10 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.ink.admin.dto.AdminUser;
+import net.ink.admin.entity.AdminMember;
+import net.ink.admin.repository.AdminMemberRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -28,11 +29,10 @@ public class AdminUserDetailsService implements UserDetailsService {
         List<GrantedAuthority> authorities = new ArrayList<>();
         // Add roles/authorities if necessary
         authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
-        if (adminMember.getRank() == AdminMember.RANK.SUPERVISOR) {
+        if (adminMember.getAdminRank() == AdminMember.RANK.SUPERVISOR) {
             authorities.add(new SimpleGrantedAuthority("ROLE_SUPERVISOR"));
         }
 
         return new AdminUser(adminMember, authorities);
     }
 }
-

--- a/ink-admin/src/main/resources/templates/admin-management.html
+++ b/ink-admin/src/main/resources/templates/admin-management.html
@@ -37,15 +37,15 @@
                         <td th:text="${adminMember.adminId}"></td>
                         <td th:text="${adminMember.email}"></td>
                         <td th:text="${adminMember.nickname}"></td>
-                        <td th:text="${adminMember.rank}"></td>
+                        <td th:text="${adminMember.adminRank}"></td>
                         <td>
                             <button class="btn btn-primary promote-btn" th:data-admin-id="${adminMember.adminId}"
-                                    th:data-rank="${adminMember.rank}"
-                                    th:if="${adminMember.rank != T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">승급</button>
+                                    th:data-rank="${adminMember.adminRank}"
+                                    th:if="${adminMember.adminRank != T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">승급</button>
                         </td>
                         <td>
                             <button class="btn btn-danger delete-btn" th:data-admin-id="${adminMember.adminId}"
-                                    th:if="${adminMember.rank != T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">삭제</button>
+                                    th:if="${adminMember.adminRank != T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">삭제</button>
                         </td>
                     </tr>
                     </tbody>

--- a/ink-admin/src/main/resources/templates/fragments/sidebar.html
+++ b/ink-admin/src/main/resources/templates/fragments/sidebar.html
@@ -19,15 +19,15 @@
     </li>
 
     <!-- Divider -->
-    <hr class="sidebar-divider" th:if="${adminMember.rank == T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">
+    <hr class="sidebar-divider" th:if="${adminMember.adminRank == T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">
 
     <!-- Heading -->
-    <div class="sidebar-heading" th:if="${adminMember.rank == T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">
+    <div class="sidebar-heading" th:if="${adminMember.adminRank == T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">
         어드민
     </div>
 
     <!-- Nav Item - Tables -->
-    <li class="nav-item" th:classappend="${inner == 'admin-management'}? 'active' : ''" th:if="${adminMember.rank == T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">
+    <li class="nav-item" th:classappend="${inner == 'admin-management'}? 'active' : ''" th:if="${adminMember.adminRank == T(net.ink.admin.entity.AdminMember.RANK).SUPERVISOR}">
         <a class="nav-link" th:href="@{/admin-management}">
             <i class="fas fa-fw fa-users"></i>
             <span>어드민 관리</span></a>

--- a/ink-admin/src/main/resources/templates/profile.html
+++ b/ink-admin/src/main/resources/templates/profile.html
@@ -24,7 +24,7 @@
                         </tr>
                         <tr>
                             <th>Rank</th>
-                            <td th:text="${adminMember.rank}"></td>
+                            <td th:text="${adminMember.adminRank}"></td>
                         </tr>
                         <tr>
                             <th>Registration Date</th>

--- a/ink-admin/src/test/java/net/ink/admin/config/WithMockInkAdminUserSecurityContextFactory.java
+++ b/ink-admin/src/test/java/net/ink/admin/config/WithMockInkAdminUserSecurityContextFactory.java
@@ -1,8 +1,8 @@
 package net.ink.admin.config;
 
-import net.ink.admin.annotation.WithMockInkAdminUser;
-import net.ink.admin.dto.AdminUser;
-import net.ink.admin.entity.AdminMember;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -11,8 +11,9 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import net.ink.admin.annotation.WithMockInkAdminUser;
+import net.ink.admin.dto.AdminUser;
+import net.ink.admin.entity.AdminMember;
 
 public class WithMockInkAdminUserSecurityContextFactory implements WithSecurityContextFactory<WithMockInkAdminUser> {
     @Override
@@ -22,15 +23,14 @@ public class WithMockInkAdminUserSecurityContextFactory implements WithSecurityC
         // Add roles/authorities if necessary
         authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
         authorities.add(new SimpleGrantedAuthority("ROLE_SUPERVISOR"));
-        AdminUser principal =
-                new AdminUser(AdminMember.builder()
-                        .adminId(1L)
-                        .email("test@email.com")
-                        .nickname("테스트")
-                        .rank(AdminMember.RANK.SUPERVISOR)
-                        .password("password").build(), authorities);
-        Authentication auth =
-                new UsernamePasswordAuthenticationToken(principal, "password", principal.getAuthorities());
+        AdminUser principal = new AdminUser(AdminMember.builder()
+                .adminId(1L)
+                .email("test@email.com")
+                .nickname("테스트")
+                .adminRank(AdminMember.RANK.SUPERVISOR)
+                .password("password").build(), authorities);
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, "password",
+                principal.getAuthorities());
         context.setAuthentication(auth);
         return context;
     }

--- a/ink-admin/src/test/java/net/ink/admin/repository/AdminMemberRepositoryTest.java
+++ b/ink-admin/src/test/java/net/ink/admin/repository/AdminMemberRepositoryTest.java
@@ -1,16 +1,17 @@
 package net.ink.admin.repository;
 
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import net.ink.admin.entity.AdminMember;
-import net.ink.core.annotation.InkDataTest;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import static net.ink.admin.entity.AdminMember.RANK.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 
-import static net.ink.admin.entity.AdminMember.RANK.PENDING;
-import static net.ink.admin.entity.AdminMember.RANK.SUPERVISOR;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import net.ink.admin.entity.AdminMember;
+import net.ink.core.annotation.InkDataTest;
 
 @InkDataTest
 class AdminMemberRepositoryTest {
@@ -25,7 +26,7 @@ class AdminMemberRepositoryTest {
         Optional<AdminMember> result = adminMemberRepository.findByEmail("admin1@exmaple.com");
         assertTrue(result.isPresent());
         assertEquals("Admin One", result.get().getNickname());
-        assertEquals(SUPERVISOR, result.get().getRank());
+        assertEquals(SUPERVISOR, result.get().getAdminRank());
     }
 
     @Test
@@ -33,12 +34,13 @@ class AdminMemberRepositoryTest {
             "classpath:dbunit/entity/admin_member.xml",
     })
     void findByEmailAndRankNot() {
-        Optional<AdminMember> result = adminMemberRepository.findByEmailAndRankNot("admin1@exmaple.com", SUPERVISOR);
+        Optional<AdminMember> result = adminMemberRepository.findByEmailAndAdminRankNot("admin1@exmaple.com",
+                SUPERVISOR);
         assertFalse(result.isPresent());
-        result = adminMemberRepository.findByEmailAndRankNot("admin1@exmaple.com", PENDING);
+        result = adminMemberRepository.findByEmailAndAdminRankNot("admin1@exmaple.com", PENDING);
         assertTrue(result.isPresent());
         assertEquals("Admin One", result.get().getNickname());
-        assertEquals(SUPERVISOR, result.get().getRank());
+        assertEquals(SUPERVISOR, result.get().getAdminRank());
     }
 
     @Test

--- a/ink-admin/src/test/java/net/ink/admin/service/AdminMemberServiceTest.java
+++ b/ink-admin/src/test/java/net/ink/admin/service/AdminMemberServiceTest.java
@@ -1,8 +1,11 @@
 package net.ink.admin.service;
 
-import net.ink.admin.entity.AdminMember;
-import net.ink.admin.repository.AdminMemberRepository;
-import net.ink.core.core.exception.BadRequestException;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,13 +14,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 
-import javax.mail.internet.MimeMessage;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import net.ink.admin.entity.AdminMember;
+import net.ink.admin.repository.AdminMemberRepository;
+import net.ink.core.core.exception.BadRequestException;
 
 @SpringBootTest
 class AdminMemberServiceTest {
@@ -68,9 +67,8 @@ class AdminMemberServiceTest {
                 AdminMember.builder()
                         .nickname("test")
                         .email("test@email.com")
-                        .rank(AdminMember.RANK.PENDING)
-                        .build())
-        );
+                        .adminRank(AdminMember.RANK.PENDING)
+                        .build()));
 
         adminMemberService.deleteAdminMemberById(1L);
     }
@@ -82,9 +80,8 @@ class AdminMemberServiceTest {
                 AdminMember.builder()
                         .nickname("test")
                         .email("test@email.com")
-                        .rank(AdminMember.RANK.SUPERVISOR)
-                        .build())
-        );
+                        .adminRank(AdminMember.RANK.SUPERVISOR)
+                        .build()));
 
         assertThrows(BadRequestException.class, () -> adminMemberService.deleteAdminMemberById(1L));
     }
@@ -94,7 +91,7 @@ class AdminMemberServiceTest {
     void promoteAdminMemberByIdInputEmailSend() {
         AdminMember adminMember = new AdminMember();
         adminMember.getAdminId();
-        adminMember.setRank(AdminMember.RANK.PENDING);
+        adminMember.setAdminRank(AdminMember.RANK.PENDING);
         adminMember.setEmail("test3@email.com");
         when(adminMemberRepository.findById(1L)).thenReturn(Optional.of(adminMember));
 

--- a/ink-core/src/main/resources/config/liquibase/changelog/20250329_rename_admin_rank_column.xml
+++ b/ink-core/src/main/resources/config/liquibase/changelog/20250329_rename_admin_rank_column.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20250329" author="hkpark">
+        <renameColumn tableName="admin_member" oldColumnName="rank" newColumnName="admin_rank" />
+    </changeSet>
+</databaseChangeLog> 

--- a/ink-core/src/main/resources/config/liquibase/master.xml
+++ b/ink-core/src/main/resources/config/liquibase/master.xml
@@ -24,4 +24,5 @@
     <include file="config/liquibase/changelog/20241124_add_reply_report_status.xml" />
     <include file="config/liquibase/changelog/20250310_add_member_report_status.xml" />
     <include file="config/liquibase/changelog/20250310_add_reply_report_process_fields.xml" />
+    <include file="config/liquibase/changelog/20250329_rename_admin_rank_column.xml" />
 </databaseChangeLog>

--- a/ink-core/src/main/resources/local-test-data.sql
+++ b/ink-core/src/main/resources/local-test-data.sql
@@ -55,17 +55,17 @@ INSERT INTO badge_accomplished (badge_id, member_id, reg_date, is_checked) VALUE
 INSERT INTO badge_accomplished (badge_id, member_id, reg_date, is_checked) VALUES (2, 1, '2021-07-08 11:13:51.113911', false);
 
 INSERT INTO admin_member
-(admin_id, email, password, nickname, rank, is_active, reg_date, mod_date)
+(admin_id, email, password, nickname, admin_rank, is_active, reg_date, mod_date)
 VALUES
     (1, 'test@email.com', '$2a$10$/PnmsvW7V2bSb9gyPgJPwukDBz4E4nnVQwzgoZUzRdXFx10ZLvGXy', '테스트', 'SUPERVISOR', true, '2023-04-13 10:30:00', '2023-04-13 10:30:00');
 
 INSERT INTO admin_member
-(admin_id, email, password, nickname, rank, is_active, reg_date, mod_date)
+(admin_id, email, password, nickname, admin_rank, is_active, reg_date, mod_date)
 VALUES
     (2, 'test2@email.com', '$2a$10$/PnmsvW7V2bSb9gyPgJPwukDBz4E4nnVQwzgoZUzRdXFx10ZLvGXy', '테스트2', 'MANAGER', true, '2023-04-13 10:30:00', '2023-04-13 10:30:00');
 
 INSERT INTO admin_member
-(admin_id, email, password, nickname, rank, is_active, reg_date, mod_date)
+(admin_id, email, password, nickname, admin_rank, is_active, reg_date, mod_date)
 VALUES
     (3, 'test3@email.com', '$2a$10$/PnmsvW7V2bSb9gyPgJPwukDBz4E4nnVQwzgoZUzRdXFx10ZLvGXy', '테스트3', 'PENDING', true, '2023-04-13 10:30:00', '2023-04-13 10:30:00');
 

--- a/ink-core/src/test/resources/dbunit/entity/admin_member.xml
+++ b/ink-core/src/test/resources/dbunit/entity/admin_member.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
-    <admin_member admin_id="1" email="admin1@exmaple.com" password="$2a$10$yS6UgKE6UvT6T22e6qZg4e4iGnE1lHmIgNaxa1D9a6MPhEiKjFwZC"
-                  nickname="Admin One" is_active="1" rank="SUPERVISOR" reg_date="2022-01-01 00:00:00" mod_date="2022-01-01 00:00:00"/>
-    <admin_member admin_id="2" email="admin2@exmaple.com" password="$2a$10$wY1u8qdLvnh11HYV0I9XQO1yT6TlT6Uc4g4f3q3ZkD1i0zUk9a9XG"
-                  nickname="Admin Two" is_active="1" rank="MANAGER" reg_date="2022-01-02 00:00:00" mod_date="2022-01-02 00:00:00"/>
-    <admin_member admin_id="3" email="admin3@exmaple.com" password="$2a$10$Q1dNkC6xN7s4p4qgI4D4Ce1yMzHrEXr9f3lL8uG1xHv7i0aD2QV7W"
-                  nickname="Admin Three" is_active="1" rank="PENDING" reg_date="2022-01-03 00:00:00" mod_date="2022-01-03 00:00:00"/>
+    <admin_member admin_id="1" email="admin1@exmaple.com"
+        password="$2a$10$yS6UgKE6UvT6T22e6qZg4e4iGnE1lHmIgNaxa1D9a6MPhEiKjFwZC"
+        nickname="Admin One" is_active="1" admin_rank="SUPERVISOR" reg_date="2022-01-01 00:00:00"
+        mod_date="2022-01-01 00:00:00" />
+    <admin_member admin_id="2" email="admin2@exmaple.com"
+        password="$2a$10$wY1u8qdLvnh11HYV0I9XQO1yT6TlT6Uc4g4f3q3ZkD1i0zUk9a9XG"
+        nickname="Admin Two" is_active="1" admin_rank="MANAGER" reg_date="2022-01-02 00:00:00"
+        mod_date="2022-01-02 00:00:00" />
+    <admin_member admin_id="3" email="admin3@exmaple.com"
+        password="$2a$10$Q1dNkC6xN7s4p4qgI4D4Ce1yMzHrEXr9f3lL8uG1xHv7i0aD2QV7W"
+        nickname="Admin Three" is_active="1" admin_rank="PENDING" reg_date="2022-01-03 00:00:00"
+        mod_date="2022-01-03 00:00:00" />
 </dataset>


### PR DESCRIPTION
- rank 속성을 adminRank로 변경
- AdminAuthenticationSuccessHandler, AdminMemberService, AdminUser, AdminMemberRepository 등에서 관련 코드 수정
- HTML 템플릿에서 rank 속성 참조를 adminRank로 업데이트

## 작업 내용 설명
- 

## 주요 변경 사항
-

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #

@NaLDo627 @jincastle
