### PR TITLE
회원 가입 및 이메일 중복 체크 기능 추가

### DIFF
--- a/ink-api/src/main/java/net/ink/api/member/service/MemberSignupService.java
+++ b/ink-api/src/main/java/net/ink/api/member/service/MemberSignupService.java
@@ -32,7 +32,7 @@ public class MemberSignupService {
         afterSignUp(savedMember);
         return savedMember;
     }
-    
+
     private boolean isDroppedOutMember(Member member) {
         return memberService.isMemberExistIncludingDropped(member.getIdentifier());
     }

--- a/ink-api/src/main/java/net/ink/api/member/web/MemberController.java
+++ b/ink-api/src/main/java/net/ink/api/member/web/MemberController.java
@@ -31,42 +31,35 @@ public class MemberController {
     @ApiOperation(value = "신규 회원 가입", notes = "신규 회원가입입니다.")
     @PostMapping("/signup")
     public ResponseEntity<ApiResult<MemberDto.ReadOnly>> signup(
-            @ApiParam(value = "신규 회원 정보", required = true)
-            @RequestBody @Valid MemberDto memberDto) {
+            @ApiParam(value = "신규 회원 정보", required = true) @RequestBody @Valid MemberDto memberDto) {
 
         Member newMember = memberMapper.toEntity(memberDto);
         return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(
-                memberSignupService.signup(newMember)
-        )));
+                memberSignupService.signup(newMember))));
     }
 
     @ApiOperation(value = "회원 정보 수정", notes = "회원 정보 수정입니다.")
     @PatchMapping("/modify")
     public ResponseEntity<ApiResult<MemberDto.ReadOnly>> modify(
             @CurrentUser Member member,
-            @ApiParam(value = "변경할 회원 정보", required = true)
-            @RequestBody MemberModifyDto memberModifyDto) {
+            @ApiParam(value = "변경할 회원 정보", required = true) @RequestBody MemberModifyDto memberModifyDto) {
 
         member.updateMember(
                 Member.builder()
                         .nickname(memberModifyDto.getNickname())
                         .image(memberModifyDto.getImage())
-                        .build()
-        );
+                        .build());
         return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(
-                memberService.saveMember(member)
-        )));
+                memberService.updateMember(member))));
     }
 
     @ApiOperation(value = "중복 닉네임 체크", notes = "사용하려는 닉네임이 중복인지 체크합니다.")
     @GetMapping("/nickname-exists/{nickname}")
     public ResponseEntity<ApiResult<DuplicatedCheckDto>> nicknameExists(
-            @ApiParam(value = "신규 회원 정보", required = true)
-            @PathVariable String nickname) {
+            @ApiParam(value = "신규 회원 정보", required = true) @PathVariable String nickname) {
 
         return ResponseEntity.ok(ApiResult.ok(
-                new DuplicatedCheckDto(memberService.isNicknameDuplicated(nickname))
-        ));
+                new DuplicatedCheckDto(memberService.isNicknameDuplicated(nickname))));
     }
 
     @ApiOperation(value = "로그인한 사용자 가져오기", notes = "현재 로그인한 사용자를 가져옵니다.")
@@ -78,10 +71,9 @@ public class MemberController {
     @ApiOperation(value = "특정 사용자의 프로필 가져오기", notes = "특정 사용자의 프로필 정보를 가져옵니다.")
     @GetMapping("/{memberId}")
     public ResponseEntity<ApiResult<MemberDto.ReadOnly>> getMemberProfile(@CurrentUser Member member,
-            @ApiParam(value = "사용자 id", required = true) @PathVariable Long memberId ) {
+            @ApiParam(value = "사용자 id", required = true) @PathVariable Long memberId) {
         return ResponseEntity.ok(ApiResult.ok(
-                memberMapper.toDto(memberService.findById(memberId))
-        ));
+                memberMapper.toDto(memberService.findById(memberId))));
     }
 
     @ApiOperation(value = "로그인한 사용자 탈퇴", notes = "현재 로그인한 사용자를 탈퇴시킵니다. " +
@@ -100,7 +92,8 @@ public class MemberController {
     }
 
     @NoArgsConstructor
-    @Getter @Setter // TODO : 외부 파일로 분리
+    @Getter
+    @Setter // TODO : 외부 파일로 분리
     public static class MemberModifyDto {
         @ApiModelProperty(value = "닉네임")
         private String nickname;

--- a/ink-api/src/test/java/net/ink/api/member/web/MemberControllerTest.java
+++ b/ink-api/src/test/java/net/ink/api/member/web/MemberControllerTest.java
@@ -20,253 +20,288 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberControllerTest extends AbstractControllerTest {
-    private final LocalDate todayDate = Instant.now().atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
-    private final String todayDateString = todayDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.KOREA));
+        private final LocalDate todayDate = Instant.now().atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
+        private final String todayDateString = todayDate
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.KOREA));
 
-    @Test
-    public void 사용자_회원가입_테스트() throws Exception {
-        String newMemberJsonString = "{" +
-                "  \"email\": \"example@email.com\",\n" +
-                "  \"identifier\": \"user-identifier\",\n" +
-                "  \"image\": \"image-path\",\n" +
-                "  \"nickname\": \"최대여섯글자\",\n" +
-                "  \"pushActive\": true\n" +
-                "}";
+        @Test
+        public void 사용자_회원가입_테스트() throws Exception {
+                String newMemberJsonString = "{" +
+                                "  \"email\": \"example@email.com\",\n" +
+                                "  \"identifier\": \"kakao_1234567890\",\n" +
+                                "  \"image\": \"image-path\",\n" +
+                                "  \"nickname\": \"테스트닉네임\",\n" +
+                                "  \"pushActive\": true\n" +
+                                "}";
 
-        mockMvc.perform(
-                post("/api/member/signup")
-                .content(newMemberJsonString)
-                .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("user-identifier"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("최대여섯글자"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
-    }
+                mockMvc.perform(
+                                post("/api/member/signup")
+                                                .content(newMemberJsonString)
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                // .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier")
+                                                .value("kakao_1234567890"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트닉네임"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true));
+        }
 
-    @Test
-    public void 사용자_회원가입_테스트_이메일_없음() throws Exception {
-        String newMemberJsonString = "{" +
-                "  \"identifier\": \"user-identifier\",\n" +
-                "  \"image\": \"image-path\",\n" +
-                "  \"nickname\": \"최대여섯글자\",\n" +
-                "  \"pushActive\": true\n" +
-                "}";
+        @Test
+        public void 사용자_회원가입_테스트_이메일_없음() throws Exception {
+                String newMemberJsonString = "{" +
+                                "  \"identifier\": \"kakao_1234567890\",\n" +
+                                "  \"image\": \"image-path\",\n" +
+                                "  \"nickname\": \"테스트닉네임\",\n" +
+                                "  \"pushActive\": true\n" +
+                                "}";
 
-        mockMvc.perform(
-                        post("/api/member/signup")
-                                .content(newMemberJsonString)
-                                .contentType(MediaType.APPLICATION_JSON)
-                ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").doesNotExist())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("user-identifier"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("최대여섯글자"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
-    }
+                mockMvc.perform(
+                                post("/api/member/signup")
+                                                .content(newMemberJsonString)
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                // .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").doesNotExist())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier")
+                                                .value("kakao_1234567890"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트닉네임"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true));
+        }
 
-    @Test
-    public void 사용자_회원가입_닉네임초과_테스트() throws Exception {
-        String newMemberJsonStringOverNickname = "{" +
-                "  \"email\": \"example@email.com\",\n" +
-                "  \"identifier\": \"user-identifier\",\n" +
-                "  \"image\": \"image-path\",\n" +
-                "  \"nickname\": \"최대여섯글자초과\",\n" +
-                "  \"pushActive\": true\n" +
-                "}";
+        @Test
+        public void 사용자_회원가입_닉네임초과_테스트() throws Exception {
+                String newMemberJsonStringOverNickname = "{" +
+                                "  \"email\": \"example@email.com\",\n" +
+                                "  \"identifier\": \"kakao_1234567890\",\n" +
+                                "  \"image\": \"image-path\",\n" +
+                                "  \"nickname\": \"매우긴닉네임테스트\",\n" +
+                                "  \"pushActive\": true\n" +
+                                "}";
 
-        mockMvc.perform(
-                post("/api/member/signup")
-                        .content(newMemberJsonStringOverNickname)
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("user-identifier"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("최대여섯글자"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
-    }
+                mockMvc.perform(
+                                post("/api/member/signup")
+                                                .content(newMemberJsonStringOverNickname)
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                // .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier")
+                                                .value("kakao_1234567890"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("매우긴닉네임"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true));
+        }
 
-    @Test
-    public void 사용자_닉네임중복체크_테스트() throws Exception {
-        mockMvc.perform(
-                get("/api/member/nickname-exists/테스트이름")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.duplicated").value(false));
-    }
+        @Test
+        public void 사용자_닉네임중복체크_테스트() throws Exception {
+                mockMvc.perform(
+                                get("/api/member/nickname-exists/테스트이름")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.duplicated").value(false));
+        }
 
-    @Test
-    public void 사용자_닉네임중복체크_테스트2() throws Exception {
-        mockMvc.perform(
-                get("/api/member/nickname-exists/테스트유저")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.duplicated").value(true));
-    }
+        @Test
+        public void 사용자_닉네임중복체크_테스트2() throws Exception {
+                mockMvc.perform(
+                                get("/api/member/nickname-exists/테스트유저")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.duplicated").value(true));
+        }
 
-    @Test
-    @WithMockInkUser
-    public void 사용자_정보수정_테스트() throws Exception {
-        mockMvc.perform(
-                patch("/api/member/modify")
-                        .content("{\"nickname\": \"변경된닉네임\", \"image\": \"modified-image-path\"}")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("modified-image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경된닉네임"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
-    }
+        @Test
+        @WithMockInkUser
+        public void 사용자_정보수정_테스트() throws Exception {
+                mockMvc.perform(
+                                patch("/api/member/modify")
+                                                .content("{\"nickname\": \"변경닉네임\", \"image\": \"modified-image-path\"}")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("modified-image-path"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경닉네임"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true));
+        }
 
-    @Test
-    @WithMockInkUser
-    public void 사용자_정보_닉네임수정_테스트() throws Exception {
-        mockMvc.perform(
-                patch("/api/member/modify")
-                        .content("{\"nickname\": \"변경된닉네임\"}")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("/reply/1621586761110.png"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경된닉네임"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
-    }
+        @Test
+        @WithMockInkUser
+        public void 사용자_정보_닉네임수정_테스트() throws Exception {
+                mockMvc.perform(
+                                patch("/api/member/modify")
+                                                .content("{\"nickname\": \"변경닉네임\"}")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image")
+                                                .value("/reply/1621586761110.png"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경닉네임"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true));
+        }
 
-    @Test
-    @WithMockInkUser
-    public void 사용자_정보_닉네임수정_닉네임초과_테스트() throws Exception {
-        mockMvc.perform(
-                patch("/api/member/modify")
-                        .content("{\"nickname\": \"변경된닉네임초과\"}")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("/reply/1621586761110.png"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경된닉네임"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
-    }
+        @Test
+        @WithMockInkUser
+        public void 사용자_정보_닉네임수정_닉네임초과_테스트() throws Exception {
+                mockMvc.perform(
+                                patch("/api/member/modify")
+                                                .content("{\"nickname\": \"매우긴닉네임테스트\"}")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image")
+                                                .value("/reply/1621586761110.png"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("매우긴닉네임"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true));
+        }
 
-    @Test
-    @WithMockInkUser
-    public void 로그인한_사용자_가져오기_테스트() throws Exception {
-        mockMvc.perform(
-                get("/api/member/me")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("/reply/1621586761110.png"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true))
-                .andDo(print());
-    }
+        @Test
+        @WithMockInkUser
+        public void 로그인한_사용자_가져오기_테스트() throws Exception {
+                mockMvc.perform(
+                                get("/api/member/me")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image")
+                                                .value("/reply/1621586761110.png"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true))
+                                .andDo(print());
+        }
 
-    @Test
-    @Disabled("해외에서 타임존 문제 - h2에 저장하고 꺼내올 때 1일 전으로 가져와진다..")
-    @WithMockInkUser
-    public void 출석체크_테스트() throws Exception {
-        // 두 번 호출 했어도 attendanceCount는 같아야 한다.
-        mockMvc.perform(
-                get("/api/member/me")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk());
+        @Test
+        @Disabled("해외에서 타임존 문제 - h2에 저장하고 꺼내올 때 1일 전으로 가져와진다..")
+        @WithMockInkUser
+        public void 출석체크_테스트() throws Exception {
+                // 두 번 호출 했어도 attendanceCount는 같아야 한다.
+                mockMvc.perform(
+                                get("/api/member/me")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(
-                get("/api/member/me")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("/reply/1621586761110.png"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true))
-                .andDo(print());
-    }
+                mockMvc.perform(
+                                get("/api/member/me")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image")
+                                                .value("/reply/1621586761110.png"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate")
+                                                .value(todayDateString))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true))
+                                .andDo(print());
+        }
 
-    @Test
-    @WithMockInkUser
-    public void 사용자_프로필_가져오기_테스트() throws Exception {
-        mockMvc.perform(
-                get("/api/member/{memberId}", 1)
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("/reply/1621586761110.png"))
-//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
-//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true))
-                .andDo(print());
+        @Test
+        @WithMockInkUser
+        public void 사용자_프로필_가져오기_테스트() throws Exception {
+                mockMvc.perform(
+                                get("/api/member/{memberId}", 1)
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image")
+                                                .value("/reply/1621586761110.png"))
+                                // .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value(todayDateString))
+                                // .andExpect(MockMvcResultMatchers.jsonPath("$.data.attendanceCount").value(1))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.inkCount").value(0))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive")
+                                                .value(true))
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive")
+                                                .value(true))
+                                .andDo(print());
 
-    }
+        }
 
-    @Test
-    @WithMockInkUser
-    public void 사용자_탈퇴_테스트() throws Exception {
-        mockMvc.perform(
-                delete("/api/member/me")
-                        .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andDo(print());
-    }
+        @Test
+        @WithMockInkUser
+        public void 사용자_탈퇴_테스트() throws Exception {
+                mockMvc.perform(
+                                delete("/api/member/me")
+                                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                                .andDo(print());
+        }
 }

--- a/ink-core/src/main/java/net/ink/core/core/message/ErrorMessage.java
+++ b/ink-core/src/main/java/net/ink/core/core/message/ErrorMessage.java
@@ -10,6 +10,8 @@ public class ErrorMessage {
     // Member
     public static String NOT_EXIST_MEMBER = "존재하지 않는 사용자입니다.";
     public static String DUPLICATED_NICKNAME = "이미 사용 중인 닉네임입니다.";
+    public static String DUPLICATED_EMAIL = "이미 사용 중인 이메일입니다.";
+    public static String INVALID_IDENTIFIER = "올바르지 않은 식별자입니다.";
     public static String ALREADY_ANSWERED_MEMBER = "이미 오늘 답변한 사용자입니다.";
 
     // Question

--- a/ink-core/src/main/java/net/ink/core/member/repository/MemberRepository.java
+++ b/ink-core/src/main/java/net/ink/core/member/repository/MemberRepository.java
@@ -19,6 +19,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByIdentifierAndIsActive(String identifier, Boolean active);
 
+    boolean existsByEmailAndIsActive(String email, Boolean active);
+
     List<Member> findAllByIsActive(Boolean active);
 
     List<Member> findAll();

--- a/ink-core/src/main/java/net/ink/core/member/service/MemberService.java
+++ b/ink-core/src/main/java/net/ink/core/member/service/MemberService.java
@@ -28,6 +28,14 @@ public class MemberService {
             throw new BadRequestException(DUPLICATED_NICKNAME);
         }
 
+        if (isEmailDuplicated(newMember.getEmail())) {
+            throw new BadRequestException(DUPLICATED_EMAIL);
+        }
+
+        if (!isIdentifierValid(newMember.getIdentifier())) {
+            throw new BadRequestException(INVALID_IDENTIFIER);
+        }
+
         return memberRepository.saveAndFlush(newMember);
     }
 
@@ -51,6 +59,15 @@ public class MemberService {
     @Transactional(readOnly = true)
     public boolean isNicknameDuplicated(String nickname) {
         return memberRepository.existsByNicknameAndIsActive(nickname, true);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isEmailDuplicated(String email) {
+        return memberRepository.existsByEmailAndIsActive(email, true);
+    }
+
+    private boolean isIdentifierValid(String identifier) {
+        return identifier != null && identifier.matches("^kakao_\\d{10}$");
     }
 
     @Transactional(readOnly = true)

--- a/ink-core/src/test/java/net/ink/core/member/service/MemberServiceTest.java
+++ b/ink-core/src/test/java/net/ink/core/member/service/MemberServiceTest.java
@@ -1,0 +1,480 @@
+package net.ink.core.member.service;
+
+import static net.ink.core.core.message.ErrorMessage.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import net.ink.core.core.exception.BadRequestException;
+import net.ink.core.core.exception.ResourceNotFoundException;
+import net.ink.core.member.entity.Member;
+import net.ink.core.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("멤버 저장 성공 테스트")
+    void saveMember_Success() {
+        // Arrange
+        Member newMember = Member.builder()
+                .identifier("kakao_1234567890")
+                .email("test@example.com")
+                .nickname("testUser")
+                .isActive(true)
+                .isSuspended(false)
+                .build();
+
+        given(memberRepository.existsByNicknameAndIsActive("testUser", true)).willReturn(false);
+        given(memberRepository.existsByEmailAndIsActive("test@example.com", true)).willReturn(false);
+        given(memberRepository.saveAndFlush(newMember)).willReturn(newMember);
+
+        // Act
+        Member savedMember = memberService.saveMember(newMember);
+
+        // Assert
+        assertNotNull(savedMember);
+        assertEquals("testUser", savedMember.getNickname());
+        assertEquals("test@example.com", savedMember.getEmail());
+        verify(memberRepository).saveAndFlush(newMember);
+    }
+
+    @Test
+    @DisplayName("멤버 저장 실패 - 닉네임 중복")
+    void saveMember_DuplicatedNickname() {
+        // Arrange
+        Member newMember = Member.builder()
+                .identifier("kakao_1234567890")
+                .email("test@example.com")
+                .nickname("duplicatedNickname")
+                .build();
+
+        given(memberRepository.existsByNicknameAndIsActive("duplicatedNickname", true)).willReturn(true);
+
+        // Act & Assert
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            memberService.saveMember(newMember);
+        });
+
+        assertEquals(DUPLICATED_NICKNAME, exception.getMessage());
+        verify(memberRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("멤버 저장 실패 - 이메일 중복")
+    void saveMember_DuplicatedEmail() {
+        // Arrange
+        Member newMember = Member.builder()
+                .identifier("kakao_1234567890")
+                .email("duplicated@example.com")
+                .nickname("testUser")
+                .build();
+
+        given(memberRepository.existsByNicknameAndIsActive("testUser", true)).willReturn(false);
+        given(memberRepository.existsByEmailAndIsActive("duplicated@example.com", true)).willReturn(true);
+
+        // Act & Assert
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            memberService.saveMember(newMember);
+        });
+
+        assertEquals(DUPLICATED_EMAIL, exception.getMessage());
+        verify(memberRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("멤버 저장 실패 - 잘못된 식별자")
+    void saveMember_InvalidIdentifier() {
+        // Arrange
+        Member newMember = Member.builder()
+                .identifier("invalid_identifier")
+                .email("test@example.com")
+                .nickname("testUser")
+                .build();
+
+        given(memberRepository.existsByNicknameAndIsActive("testUser", true)).willReturn(false);
+        given(memberRepository.existsByEmailAndIsActive("test@example.com", true)).willReturn(false);
+
+        // Act & Assert
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            memberService.saveMember(newMember);
+        });
+
+        assertEquals(INVALID_IDENTIFIER, exception.getMessage());
+        verify(memberRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("멤버 업데이트 성공 테스트")
+    void updateMember_Success() {
+        // Arrange
+        Member member = Member.builder()
+                .memberId(1L)
+                .identifier("kakao_1234567890")
+                .email("test@example.com")
+                .nickname("updatedUser")
+                .build();
+
+        given(memberRepository.saveAndFlush(member)).willReturn(member);
+
+        // Act
+        Member updatedMember = memberService.updateMember(member);
+
+        // Assert
+        assertNotNull(updatedMember);
+        assertEquals("updatedUser", updatedMember.getNickname());
+        verify(memberRepository).saveAndFlush(member);
+    }
+
+    @Test
+    @DisplayName("멤버 탈퇴 처리 테스트")
+    void dropOutMember_Success() {
+        // Arrange
+        Member member = Member.builder()
+                .memberId(1L)
+                .identifier("kakao_1234567890")
+                .email("test@example.com")
+                .nickname("testUser")
+                .isActive(true)
+                .build();
+
+        given(memberRepository.saveAndFlush(member)).willReturn(member);
+
+        // Act
+        memberService.dropOutMember(member);
+
+        // Assert
+        assertFalse(member.getIsActive());
+        verify(memberRepository).saveAndFlush(member);
+    }
+
+    @Test
+    @DisplayName("멤버 정지 처리 테스트")
+    void suspendMember_Success() {
+        // Arrange
+        Member member = Member.builder()
+                .memberId(1L)
+                .identifier("kakao_1234567890")
+                .email("test@example.com")
+                .nickname("testUser")
+                .isSuspended(false)
+                .build();
+
+        given(memberRepository.saveAndFlush(member)).willReturn(member);
+
+        // Act
+        Member suspendedMember = memberService.suspendMember(member, true);
+
+        // Assert
+        assertTrue(suspendedMember.getIsSuspended());
+        verify(memberRepository).saveAndFlush(member);
+    }
+
+    @Test
+    @DisplayName("멤버 정지 해제 테스트")
+    void unsuspendMember_Success() {
+        // Arrange
+        Member member = Member.builder()
+                .memberId(1L)
+                .identifier("kakao_1234567890")
+                .email("test@example.com")
+                .nickname("testUser")
+                .isSuspended(true)
+                .build();
+
+        given(memberRepository.saveAndFlush(member)).willReturn(member);
+
+        // Act
+        Member unsuspendedMember = memberService.suspendMember(member, false);
+
+        // Assert
+        assertFalse(unsuspendedMember.getIsSuspended());
+        verify(memberRepository).saveAndFlush(member);
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 체크 - 중복된 경우")
+    void isNicknameDuplicated_True() {
+        // Arrange
+        String nickname = "duplicatedNickname";
+        given(memberRepository.existsByNicknameAndIsActive(nickname, true)).willReturn(true);
+
+        // Act
+        boolean result = memberService.isNicknameDuplicated(nickname);
+
+        // Assert
+        assertTrue(result);
+        verify(memberRepository).existsByNicknameAndIsActive(nickname, true);
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 체크 - 중복되지 않은 경우")
+    void isNicknameDuplicated_False() {
+        // Arrange
+        String nickname = "uniqueNickname";
+        given(memberRepository.existsByNicknameAndIsActive(nickname, true)).willReturn(false);
+
+        // Act
+        boolean result = memberService.isNicknameDuplicated(nickname);
+
+        // Assert
+        assertFalse(result);
+        verify(memberRepository).existsByNicknameAndIsActive(nickname, true);
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크 - 중복된 경우")
+    void isEmailDuplicated_True() {
+        // Arrange
+        String email = "duplicated@example.com";
+        given(memberRepository.existsByEmailAndIsActive(email, true)).willReturn(true);
+
+        // Act
+        boolean result = memberService.isEmailDuplicated(email);
+
+        // Assert
+        assertTrue(result);
+        verify(memberRepository).existsByEmailAndIsActive(email, true);
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크 - 중복되지 않은 경우")
+    void isEmailDuplicated_False() {
+        // Arrange
+        String email = "unique@example.com";
+        given(memberRepository.existsByEmailAndIsActive(email, true)).willReturn(false);
+
+        // Act
+        boolean result = memberService.isEmailDuplicated(email);
+
+        // Assert
+        assertFalse(result);
+        verify(memberRepository).existsByEmailAndIsActive(email, true);
+    }
+
+    @Test
+    @DisplayName("멤버 존재 여부 확인 - 존재하는 경우")
+    void isMemberExist_True() {
+        // Arrange
+        String identifier = "kakao_1234567890";
+        given(memberRepository.existsByIdentifierAndIsActive(identifier, true)).willReturn(true);
+
+        // Act
+        boolean result = memberService.isMemberExist(identifier);
+
+        // Assert
+        assertTrue(result);
+        verify(memberRepository).existsByIdentifierAndIsActive(identifier, true);
+    }
+
+    @Test
+    @DisplayName("멤버 존재 여부 확인 - 존재하지 않는 경우")
+    void isMemberExist_False() {
+        // Arrange
+        String identifier = "kakao_9999999999";
+        given(memberRepository.existsByIdentifierAndIsActive(identifier, true)).willReturn(false);
+
+        // Act
+        boolean result = memberService.isMemberExist(identifier);
+
+        // Assert
+        assertFalse(result);
+        verify(memberRepository).existsByIdentifierAndIsActive(identifier, true);
+    }
+
+    @Test
+    @DisplayName("탈퇴 포함 멤버 존재 여부 확인 - 존재하는 경우")
+    void isMemberExistIncludingDropped_True() {
+        // Arrange
+        String identifier = "kakao_1234567890";
+        given(memberRepository.existsByIdentifier(identifier)).willReturn(true);
+
+        // Act
+        boolean result = memberService.isMemberExistIncludingDropped(identifier);
+
+        // Assert
+        assertTrue(result);
+        verify(memberRepository).existsByIdentifier(identifier);
+    }
+
+    @Test
+    @DisplayName("탈퇴 포함 멤버 존재 여부 확인 - 존재하지 않는 경우")
+    void isMemberExistIncludingDropped_False() {
+        // Arrange
+        String identifier = "kakao_9999999999";
+        given(memberRepository.existsByIdentifier(identifier)).willReturn(false);
+
+        // Act
+        boolean result = memberService.isMemberExistIncludingDropped(identifier);
+
+        // Assert
+        assertFalse(result);
+        verify(memberRepository).existsByIdentifier(identifier);
+    }
+
+    @Test
+    @DisplayName("활성 멤버 전체 조회 테스트")
+    void findAllActiveMembers_Success() {
+        // Arrange
+        List<Member> activeMembers = Arrays.asList(
+                Member.builder().memberId(1L).nickname("user1").isActive(true).build(),
+                Member.builder().memberId(2L).nickname("user2").isActive(true).build());
+        given(memberRepository.findAllByIsActive(true)).willReturn(activeMembers);
+
+        // Act
+        List<Member> result = memberService.findAllActiveMembers();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(Member::getIsActive));
+        verify(memberRepository).findAllByIsActive(true);
+    }
+
+    @Test
+    @DisplayName("전체 멤버 조회 테스트")
+    void findAllMembers_Success() {
+        // Arrange
+        List<Member> allMembers = Arrays.asList(
+                Member.builder().memberId(1L).nickname("user1").isActive(true).build(),
+                Member.builder().memberId(2L).nickname("user2").isActive(false).build());
+        given(memberRepository.findAll()).willReturn(allMembers);
+
+        // Act
+        List<Member> result = memberService.findAllMembers();
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(memberRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("식별자로 멤버 조회 성공 테스트")
+    void findByIdentifier_Success() {
+        // Arrange
+        String identifier = "kakao_1234567890";
+        Member member = Member.builder()
+                .memberId(1L)
+                .identifier(identifier)
+                .nickname("testUser")
+                .isActive(true)
+                .build();
+        given(memberRepository.findByIdentifierAndIsActive(identifier, true)).willReturn(Optional.of(member));
+
+        // Act
+        Member result = memberService.findByIdentifier(identifier);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(identifier, result.getIdentifier());
+        verify(memberRepository).findByIdentifierAndIsActive(identifier, true);
+    }
+
+    @Test
+    @DisplayName("식별자로 멤버 조회 실패 - 존재하지 않는 멤버")
+    void findByIdentifier_NotFound() {
+        // Arrange
+        String identifier = "kakao_9999999999";
+        given(memberRepository.findByIdentifierAndIsActive(identifier, true)).willReturn(Optional.empty());
+
+        // Act & Assert
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> {
+            memberService.findByIdentifier(identifier);
+        });
+
+        assertEquals(NOT_EXIST_MEMBER, exception.getMessage());
+        verify(memberRepository).findByIdentifierAndIsActive(identifier, true);
+    }
+
+    @Test
+    @DisplayName("탈퇴 포함 식별자로 멤버 조회 성공 테스트")
+    void findByIdentifierIncludingDropped_Success() {
+        // Arrange
+        String identifier = "kakao_1234567890";
+        Member member = Member.builder()
+                .memberId(1L)
+                .identifier(identifier)
+                .nickname("testUser")
+                .isActive(false)
+                .build();
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+
+        // Act
+        Member result = memberService.findByIdentifierIncludingDropped(identifier);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(identifier, result.getIdentifier());
+        verify(memberRepository).findByIdentifier(identifier);
+    }
+
+    @Test
+    @DisplayName("탈퇴 포함 식별자로 멤버 조회 실패 - 존재하지 않는 멤버")
+    void findByIdentifierIncludingDropped_NotFound() {
+        // Arrange
+        String identifier = "kakao_9999999999";
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.empty());
+
+        // Act & Assert
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> {
+            memberService.findByIdentifierIncludingDropped(identifier);
+        });
+
+        assertEquals(NOT_EXIST_MEMBER, exception.getMessage());
+        verify(memberRepository).findByIdentifier(identifier);
+    }
+
+    @Test
+    @DisplayName("ID로 멤버 조회 성공 테스트")
+    void findById_Success() {
+        // Arrange
+        Long memberId = 1L;
+        Member member = Member.builder()
+                .memberId(memberId)
+                .identifier("kakao_1234567890")
+                .nickname("testUser")
+                .build();
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // Act
+        Member result = memberService.findById(memberId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(memberId, result.getMemberId());
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("ID로 멤버 조회 실패 - 존재하지 않는 멤버")
+    void findById_NotFound() {
+        // Arrange
+        Long memberId = 999L;
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // Act & Assert
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> {
+            memberService.findById(memberId);
+        });
+
+        assertEquals(NOT_EXIST_MEMBER, exception.getMessage());
+        verify(memberRepository).findById(memberId);
+    }
+}


### PR DESCRIPTION
- MemberService에 이메일 중복 체크 로직 추가
- 잘못된 식별자 처리 로직 추가
- ErrorMessage에 이메일 중복 및 잘못된 식별자 메시지 추가
- MemberRepository에 이메일 중복 체크 메서드 추가
- MemberServiceTest에 이메일 중복 체크 및 잘못된 식별자 테스트 케이스 추가
- 코드 정리 및 불필요한 공백 제거

## 작업 내용 설명
- 

## 주요 변경 사항
-

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #53

@NaRDo627 @jincastle
