### PR TITLE
Fix: 다음 성능 저하가 발생할 우려가 있는 코드 들을 수정해줘 \n\n 성능 저하가 발생할 수 있는 주요 구간 : N+1 쿼리 문제 #### Member 엔티티의 EAGER 로딩 위치:...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ subprojects {
 		implementation 'org.liquibase:liquibase-core:4.3.5'
 		implementation 'com.google.firebase:firebase-admin:6.8.1'
 		implementation 'ca.pjer:logback-awslogs-appender:1.4.0'
+		implementation 'org.springframework.boot:spring-boot-starter-cache'
 	}
 
 	jacocoTestReport {

--- a/ink-admin/src/main/java/net/ink/admin/service/view/MainViewService.java
+++ b/ink-admin/src/main/java/net/ink/admin/service/view/MainViewService.java
@@ -26,7 +26,7 @@ public class MainViewService {
         return MainViewDto.builder()
                 .questionCount((int) questionRepository.count())
                 .registeredReplyCount((int) replyRepository.count())
-                .totalMemberCount((int) memberRepository.findAll().stream().filter(Member::getIsActive).count())
+                .totalMemberCount((int) memberRepository.countByIsActive(true))
                 .todayUsefulExpressions(todayUsefulExpressionRepository.findAll()
                         .stream().map(x -> usefulExpressionMapper.toDto(x.getUsefulExpression())).collect(Collectors.toList()))
                 .build();

--- a/ink-core/src/main/java/net/ink/core/config/CacheConfig.java
+++ b/ink-core/src/main/java/net/ink/core/config/CacheConfig.java
@@ -1,0 +1,22 @@
+package net.ink.core.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(
+                "questions",
+                "members",
+                "todayQuestions",
+                "todayExpressions"
+        );
+    }
+}

--- a/ink-core/src/main/java/net/ink/core/member/entity/Member.java
+++ b/ink-core/src/main/java/net/ink/core/member/entity/Member.java
@@ -75,7 +75,7 @@ public class Member {
     private LocalDateTime modDate = LocalDateTime.now();
 
     @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<CookieAcquirement> inkCookies = new HashSet<>();
 
     @Embedded

--- a/ink-core/src/main/java/net/ink/core/member/repository/MemberRepository.java
+++ b/ink-core/src/main/java/net/ink/core/member/repository/MemberRepository.java
@@ -24,4 +24,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByIsActive(Boolean active);
 
     List<Member> findAll();
+    
+    long countByIsActive(Boolean active);
 }

--- a/ink-core/src/main/java/net/ink/core/member/service/MemberService.java
+++ b/ink-core/src/main/java/net/ink/core/member/service/MemberService.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -36,24 +38,25 @@ public class MemberService {
             throw new BadRequestException(INVALID_IDENTIFIER);
         }
 
-        return memberRepository.saveAndFlush(newMember);
+        return memberRepository.save(newMember);
     }
 
     @Transactional
+    @CacheEvict(value = "members", key = "#member.memberId")
     public Member updateMember(@Valid Member member) {
-        return memberRepository.saveAndFlush(member);
+        return memberRepository.save(member);
     }
 
     @Transactional
     public void dropOutMember(@Valid Member member) {
         member.setIsActive(false);
-        memberRepository.saveAndFlush(member);
+        memberRepository.save(member);
     }
 
     @Transactional
     public Member suspendMember(@Valid Member member, boolean isSuspended) {
         member.setIsSuspended(isSuspended);
-        return memberRepository.saveAndFlush(member);
+        return memberRepository.save(member);
     }
 
     @Transactional(readOnly = true)
@@ -103,6 +106,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "members", key = "#memberId")
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_EXIST_MEMBER));

--- a/ink-core/src/main/java/net/ink/core/question/entity/Question.java
+++ b/ink-core/src/main/java/net/ink/core/question/entity/Question.java
@@ -42,6 +42,9 @@ public class Question {
     @Builder.Default
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reply> replies = new ArrayList<>();
+    
+    @Column(name = "reply_count")
+    private Integer replyCount = 0;
 
     @Builder.Default
     @Column(name = "reg_date", nullable = false)
@@ -50,5 +53,21 @@ public class Question {
     public void removeReply(Reply reply) {
         this.replies = this.replies.stream()
                 .filter(x -> !Objects.equals(x.getReplyId(), reply.getReplyId())).collect(Collectors.toList());
+        decrementReplyCount();
+    }
+    
+    public void incrementReplyCount() {
+        if (this.replyCount == null) {
+            this.replyCount = 0;
+        }
+        this.replyCount++;
+    }
+    
+    public void decrementReplyCount() {
+        if (this.replyCount == null || this.replyCount <= 0) {
+            this.replyCount = 0;
+        } else {
+            this.replyCount--;
+        }
     }
 }

--- a/ink-core/src/main/java/net/ink/core/question/repository/QuestionRepository.java
+++ b/ink-core/src/main/java/net/ink/core/question/repository/QuestionRepository.java
@@ -12,6 +12,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findAllByAuthorMemberIdOrderByRegDateDesc(Long memberId);
     boolean existsByQuestionIdAndAuthorMemberId(Long questionId, Long memberId);
 
-    @Query("Select q from Question q order by q.replies.size desc")
+    @Query("Select q from Question q order by q.replyCount desc")
     Page<Question> findAllOrderByRepliesSizeDesc(Pageable page);
 }

--- a/ink-core/src/main/java/net/ink/core/question/service/QuestionService.java
+++ b/ink-core/src/main/java/net/ink/core/question/service/QuestionService.java
@@ -5,6 +5,8 @@ import net.ink.core.core.exception.ResourceNotFoundException;
 import net.ink.core.question.entity.Question;
 import net.ink.core.question.entity.WordHint;
 import net.ink.core.question.repository.QuestionRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ public class QuestionService {
     private final WordHintService wordHintService;
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "questions", key = "#questionId")
     public Question getQuestionById(Long questionId){
         return questionRepository.findById(questionId).orElseThrow(() -> new ResourceNotFoundException(NOT_EXIST_QUESTION));
     }
@@ -35,16 +38,19 @@ public class QuestionService {
     }
 
     @Transactional
+    @CacheEvict(value = "questions", key = "#question.questionId")
     public Question update(Question question){
         return this.create(question);
     }
 
     @Transactional
+    @CacheEvict(value = "questions", allEntries = true)
     public Question create(Question question){
-        return questionRepository.saveAndFlush(question);
+        return questionRepository.save(question);
     }
 
     @Transactional
+    @CacheEvict(value = "questions", key = "#questionId")
     public void deleteById(Long questionId) {
         Question question = this.getQuestionById(questionId);
 

--- a/ink-core/src/main/java/net/ink/core/reply/entity/Reply.java
+++ b/ink-core/src/main/java/net/ink/core/reply/entity/Reply.java
@@ -70,6 +70,9 @@ public class Reply {
     @Builder.Default
     @OneToMany(mappedBy = "reply", cascade = CascadeType.ALL)
     private Set<ReplyLikes> replyLikes = new HashSet<>();
+    
+    @Column(name = "like_count")
+    private Integer likeCount = 0;
 
     @Builder.Default
     @OneToMany(mappedBy = "reply", cascade = CascadeType.ALL)
@@ -90,11 +93,23 @@ public class Reply {
             return false;
         }
 
-        for (ReplyLikes replyLikes : this.replyLikes) {
-            if (replyLikes.getId().getMemberId().equals(member.getMemberId()))
-                return true;
+        return this.replyLikes.stream()
+                .anyMatch(like -> like.getId().getMemberId().equals(member.getMemberId()));
+    }
+    
+    public void incrementLikeCount() {
+        if (this.likeCount == null) {
+            this.likeCount = 0;
         }
-        return false;
+        this.likeCount++;
+    }
+    
+    public void decrementLikeCount() {
+        if (this.likeCount == null || this.likeCount <= 0) {
+            this.likeCount = 0;
+        } else {
+            this.likeCount--;
+        }
     }
 
 }

--- a/ink-core/src/main/java/net/ink/core/reply/repository/ReplyRepository.java
+++ b/ink-core/src/main/java/net/ink/core/reply/repository/ReplyRepository.java
@@ -21,10 +21,10 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     Page<Reply> findAllByQuestionQuestionIdAndVisibleAndDeleted(Long questionId, Boolean visible, Boolean deleted,
             Pageable pageable);
 
-    @Query("Select r from Reply r where r.visible = true and r.deleted = false and r.question.questionId = :questionId order by r.replyLikes.size desc")
+    @Query("Select r from Reply r where r.visible = true and r.deleted = false and r.question.questionId = :questionId order by r.likeCount desc")
     Page<Reply> findAllByQuestionQuestionIdOrderByReplyLikesSize(Long questionId, Pageable pageable);
 
-    @Query("Select r from Reply r where r.visible = true and r.deleted = false order by r.replyLikes.size desc")
+    @Query("Select r from Reply r where r.visible = true and r.deleted = false order by r.likeCount desc")
     Page<Reply> findAllByOrderByReplyLikesSize(Pageable pageable);
 
     boolean existsByRegDateBetweenAndAuthorMemberIdAndVisibleAndDeleted(LocalDateTime startDateTime,

--- a/ink-core/src/main/java/net/ink/core/reply/service/ReplyLikesService.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/ReplyLikesService.java
@@ -34,7 +34,10 @@ public class ReplyLikesService {
 
         ReplyLikes replyLikes = ReplyLikes.builder().id(replyLikesPK).member(member).reply(reply).build();
 
-        replyLikesRepository.saveAndFlush(replyLikes);
+        replyLikesRepository.save(replyLikes);
+        
+        // Update the like count
+        reply.incrementLikeCount();
 
         badgeAccomplishedService.createCelebrityInk(replyId);
         // fcmLikePushService.pushToAuthor(reply, member);
@@ -52,6 +55,9 @@ public class ReplyLikesService {
             throw new InkException(ALREADY_CANCELED_REPLY_LIKE);
 
         replyLikesRepository.deleteById(replyLikesPK);
+        
+        // Update the like count
+        reply.decrementLikeCount();
     }
 
 }

--- a/ink-core/src/main/java/net/ink/core/reply/service/ReplyService.java
+++ b/ink-core/src/main/java/net/ink/core/reply/service/ReplyService.java
@@ -18,6 +18,7 @@ import net.ink.core.core.exception.AccessNotAllowedException;
 import net.ink.core.core.exception.BadRequestException;
 import net.ink.core.core.exception.EntityNotFoundException;
 import net.ink.core.member.entity.Member;
+import net.ink.core.question.entity.Question;
 import net.ink.core.question.service.QuestionService;
 import net.ink.core.reply.entity.Reply;
 import net.ink.core.reply.repository.ReplyRepository;
@@ -56,9 +57,14 @@ public class ReplyService {
             throw new BadRequestException(ALREADY_ANSWERED_REPLY);
 
         newReply.setAuthor(newReply.getAuthor());
-        newReply.setQuestion(questionService.getQuestionById(questionId));
+        Question question = questionService.getQuestionById(questionId);
+        newReply.setQuestion(question);
 
-        Reply savedReply = replyRepository.saveAndFlush(newReply);
+        Reply savedReply = replyRepository.save(newReply);
+        
+        // Update the reply count on question
+        question.incrementReplyCount();
+        
         replyPostProcessService.postProcess(savedReply); // TODO 이벤트 기반으로 변경
 
         return savedReply;
@@ -93,7 +99,7 @@ public class ReplyService {
 
         oldReply.modifyReply(newReply);
 
-        return replyRepository.saveAndFlush(oldReply);
+        return replyRepository.save(oldReply);
     }
 
     @Transactional

--- a/ink-core/src/main/resources/config/liquibase/changelog/20250106_add_performance_columns.xml
+++ b/ink-core/src/main/resources/config/liquibase/changelog/20250106_add_performance_columns.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20250106-01" author="system">
+        <comment>Add like_count column to reply table for performance optimization</comment>
+        <addColumn tableName="reply">
+            <column name="like_count" type="int" defaultValue="0">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="20250106-02" author="system">
+        <comment>Add reply_count column to question table for performance optimization</comment>
+        <addColumn tableName="question">
+            <column name="reply_count" type="int" defaultValue="0">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="20250106-03" author="system">
+        <comment>Initialize like_count from existing data</comment>
+        <sql>
+            UPDATE reply r
+            SET r.like_count = (
+                SELECT COUNT(*)
+                FROM reply_likes rl
+                WHERE rl.reply_id = r.reply_id
+            )
+        </sql>
+    </changeSet>
+
+    <changeSet id="20250106-04" author="system">
+        <comment>Initialize reply_count from existing data</comment>
+        <sql>
+            UPDATE question q
+            SET q.reply_count = (
+                SELECT COUNT(*)
+                FROM reply r
+                WHERE r.question_id = q.question_id
+                AND r.deleted = false
+                AND r.visible = true
+            )
+        </sql>
+    </changeSet>
+
+    <changeSet id="20250106-05" author="system">
+        <comment>Add index on like_count for sorting optimization</comment>
+        <createIndex tableName="reply" indexName="idx_reply_like_count">
+            <column name="like_count"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20250106-06" author="system">
+        <comment>Add index on reply_count for sorting optimization</comment>
+        <createIndex tableName="question" indexName="idx_question_reply_count">
+            <column name="reply_count"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/ink-core/src/main/resources/config/liquibase/master.xml
+++ b/ink-core/src/main/resources/config/liquibase/master.xml
@@ -27,4 +27,5 @@
     <include file="config/liquibase/changelog/20250329_rename_admin_rank_column.xml" />
     <include file="config/liquibase/changelog/20250401_add_member_is_suspended.xml" />
     <include file="config/liquibase/changelog/20250617_add_reply_report_method.xml" />
+    <include file="config/liquibase/changelog/20250106_add_performance_columns.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
## 오류 수정

**문제 설명:**
다음 성능 저하가 발생할 우려가 있는 코드 들을 수정해줘 \n\n 성능 저하가 발생할 수 있는 주요 구간 : N+1 쿼리 문제 #### Member 엔티티의 EAGER 로딩 위치: ink-core/src/main/java/net/ink/core/member/entity/Member.java:78 문제: inkCookies 컬렉션이 FetchType.EAGER로 설정되어 있어 Member 조회 시 항상 추가 쿼리 발생 영향: Member를 조회하는 모든 곳에서 불필요한 추가 쿼리 실행  #### Collection Size 기반 정렬 쿼리 위치:  ink-core/src/main/java/net/ink/core/reply/repository/ReplyRepository.java:24-28 ink-core/src/main/java/net/ink/core/question/repository/QuestionRepository.java:15-16 문제: order by r.replyLikes.size 같은 컬렉션 크기 기반 정렬은 메모리에서 처리되어 성능 저하 발생 영향: 대량 데이터 처리 시 메모리 사용량 증가 및 응답 지연  비효율적인 전체 조회 #### MainViewService의 findAll() 사용 위치: ink-admin/src/main/java/net/ink/admin/service/view/MainViewService.java:29-30 문제:  memberRepository.findAll().stream().filter(Member::getIsActive).count() todayUsefulExpressionRepository.findAll()  전체 데이터를 메모리로 로드 후 필터링 영향: 데이터 증가 시 메모리 부족 및 응답 시간 증가  과도한 flush() 사용 #### saveAndFlush() 과다 사용 위치:  ink-core/src/main/java/net/ink/core/reply/service/ReplyService.java:61,96 ink-core/src/main/java/net/ink/core/member/service/MemberService.java:39,44,50,56 문제: 매 저장마다 즉시 DB 동기화로 트랜잭션 성능 저하 영향: 배치 처리 불가능, DB 부하 증가  반복적인 쿼리 실행 #### Reply의 likedByRequester 메서드 위치: ink-core/src/main/java/net/ink/core/reply/entity/Reply.java:88-98 문제: 좋아요 여부 확인 시 매번 컬렉션 전체 순회 영향: 답변 목록 조회 시 O(n*m) 복잡도  캐싱 미구현 문제: @Cacheable, @CacheEvict 등 스프링 캐시 어노테이션 미사용 영향:  자주 조회되는 Question, Member 데이터 매번 DB 조회 TodayQuestion, TodayUsefulExpression 같은 일일 데이터도 캐싱 없음  권장 개선 사항 EAGER를 LAZY로 변경: Member.inkCookies를 필요 시에만 로드 카운트 쿼리 최적화: findAll().count() 대신 count() 또는 countByIsActive() 사용 정렬 최적화: 컬렉션 크기 대신 별도 카운트 컬럼 추가 캐싱 도입: Redis나 스프링 캐시로 자주 조회되는 데이터 캐싱 saveAndFlush를 save로 변경: 트랜잭션 종료 시 자동 flush 활용

**수정 내용:**

...

---
*이 PR은 Discord Bot을 통해 자동으로 생성되었습니다.*
