### PR TITLE
Fix: 치명적: EAGER Fetching으로 인한 N+1 문제 ink-core/src/main/java/net/ink/core/member/entity/Member.java:78 - i...

### DIFF
--- a/ink-admin/src/main/java/net/ink/admin/dto/mapper/MemberMapper.java
+++ b/ink-admin/src/main/java/net/ink/admin/dto/mapper/MemberMapper.java
@@ -11,7 +11,7 @@ import net.ink.core.member.entity.Member;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, imports = DateTimeFormatter.class)
 public interface MemberMapper {
-        @Mapping(target = "inkCount", expression = "java(member.getInkCookies().isEmpty() ? 0 : member.getInkCookies().size())")
+        @Mapping(target = "inkCount", ignore = true)
         @Mapping(target = "attendanceCount", expression = "java(member.getMemberAttendance().getAttendanceCount())")
         @Mapping(target = "lastAttendanceDate", expression = "java(member.getMemberAttendance().getLastAttendanceDate()"
                         +

--- a/ink-admin/src/main/java/net/ink/admin/service/AdminMemberDtoService.java
+++ b/ink-admin/src/main/java/net/ink/admin/service/AdminMemberDtoService.java
@@ -1,0 +1,24 @@
+package net.ink.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import net.ink.admin.dto.MemberDto;
+import net.ink.admin.dto.mapper.MemberMapper;
+import net.ink.core.cookie.repository.CookieAcquirementRepository;
+import net.ink.core.member.entity.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberDtoService {
+    private final MemberMapper memberMapper;
+    private final CookieAcquirementRepository cookieAcquirementRepository;
+    
+    @Transactional(readOnly = true)
+    public MemberDto toDto(Member member) {
+        MemberDto dto = memberMapper.toDto(member);
+        long inkCount = cookieAcquirementRepository.countByMemberMemberId(member.getMemberId());
+        dto.setInkCount((int) inkCount);
+        return dto;
+    }
+}

--- a/ink-api/src/main/java/net/ink/api/member/component/MemberMapper.java
+++ b/ink-api/src/main/java/net/ink/api/member/component/MemberMapper.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
         imports = DateTimeFormatter.class)
 public interface MemberMapper {
-    @Mapping(target = "inkCount", expression = "java(member.getInkCookies().isEmpty() ? 0 : member.getInkCookies().size())")
+    @Mapping(target = "inkCount", ignore = true)
     @Mapping(target = "attendanceCount", expression = "java(member.getMemberAttendance().getAttendanceCount())")
     @Mapping(target = "lastAttendanceDate", expression = "java(member.getMemberAttendance().getLastAttendanceDate()" +
             ".format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")) )")

--- a/ink-api/src/main/java/net/ink/api/member/service/MemberDtoService.java
+++ b/ink-api/src/main/java/net/ink/api/member/service/MemberDtoService.java
@@ -1,0 +1,24 @@
+package net.ink.api.member.service;
+
+import lombok.RequiredArgsConstructor;
+import net.ink.api.member.component.MemberMapper;
+import net.ink.api.member.dto.MemberDto;
+import net.ink.core.cookie.repository.CookieAcquirementRepository;
+import net.ink.core.member.entity.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDtoService {
+    private final MemberMapper memberMapper;
+    private final CookieAcquirementRepository cookieAcquirementRepository;
+    
+    @Transactional(readOnly = true)
+    public MemberDto.ReadOnly toDto(Member member) {
+        MemberDto.ReadOnly dto = memberMapper.toDto(member);
+        long inkCount = cookieAcquirementRepository.countByMemberMemberId(member.getMemberId());
+        dto.setInkCount((int) inkCount);
+        return dto;
+    }
+}

--- a/ink-api/src/main/java/net/ink/api/member/web/MemberController.java
+++ b/ink-api/src/main/java/net/ink/api/member/web/MemberController.java
@@ -10,6 +10,7 @@ import net.ink.api.core.dto.ApiResult;
 import net.ink.api.core.util.NicknameNormalizer;
 import net.ink.api.member.component.MemberMapper;
 import net.ink.api.member.dto.MemberDto;
+import net.ink.api.member.service.MemberDtoService;
 import net.ink.api.member.service.MemberSignupService;
 import net.ink.core.member.entity.Member;
 import net.ink.core.member.service.MemberService;
@@ -27,6 +28,7 @@ public class MemberController {
     private final MemberService memberService;
     private final MemberSignupService memberSignupService;
     private final MemberMapper memberMapper;
+    private final MemberDtoService memberDtoService;
 
     @ApiOperation(value = "신규 회원 가입", notes = "신규 회원가입입니다.")
     @PostMapping("/signup")
@@ -34,7 +36,7 @@ public class MemberController {
             @ApiParam(value = "신규 회원 정보", required = true) @RequestBody @Valid MemberDto memberDto) {
 
         Member newMember = memberMapper.toEntity(memberDto);
-        return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(
+        return ResponseEntity.ok(ApiResult.ok(memberDtoService.toDto(
                 memberSignupService.signup(newMember))));
     }
 
@@ -49,7 +51,7 @@ public class MemberController {
                         .nickname(memberModifyDto.getNickname())
                         .image(memberModifyDto.getImage())
                         .build());
-        return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(
+        return ResponseEntity.ok(ApiResult.ok(memberDtoService.toDto(
                 memberService.updateMember(member))));
     }
 
@@ -65,7 +67,7 @@ public class MemberController {
     @ApiOperation(value = "로그인한 사용자 가져오기", notes = "현재 로그인한 사용자를 가져옵니다.")
     @GetMapping("/me")
     public ResponseEntity<ApiResult<MemberDto.ReadOnly>> me(@CurrentUser Member member) {
-        return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(member)));
+        return ResponseEntity.ok(ApiResult.ok(memberDtoService.toDto(member)));
     }
 
     @ApiOperation(value = "특정 사용자의 프로필 가져오기", notes = "특정 사용자의 프로필 정보를 가져옵니다.")
@@ -73,7 +75,7 @@ public class MemberController {
     public ResponseEntity<ApiResult<MemberDto.ReadOnly>> getMemberProfile(@CurrentUser Member member,
             @ApiParam(value = "사용자 id", required = true) @PathVariable Long memberId) {
         return ResponseEntity.ok(ApiResult.ok(
-                memberMapper.toDto(memberService.findById(memberId))));
+                memberDtoService.toDto(memberService.findById(memberId))));
     }
 
     @ApiOperation(value = "로그인한 사용자 탈퇴", notes = "현재 로그인한 사용자를 탈퇴시킵니다. " +

--- a/ink-api/src/main/java/net/ink/api/member/web/MemberSettingController.java
+++ b/ink-api/src/main/java/net/ink/api/member/web/MemberSettingController.java
@@ -9,6 +9,7 @@ import net.ink.api.core.annotation.CurrentUser;
 import net.ink.api.core.dto.ApiResult;
 import net.ink.api.member.component.MemberMapper;
 import net.ink.api.member.dto.MemberDto;
+import net.ink.api.member.service.MemberDtoService;
 import net.ink.core.member.entity.Member;
 import net.ink.core.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberSettingController {
     private final MemberService memberService;
     private final MemberMapper memberMapper;
+    private final MemberDtoService memberDtoService;
 
     @ApiOperation(value = "좋아요 Push 알림 ON", notes = "좋아요 Push 알림을 켭니다.")
     @PutMapping("/me/setting/push/like")
@@ -28,7 +30,7 @@ public class MemberSettingController {
                                                                     @ApiParam(value = "Push 설정 여부", required = true)
                                                                     @RequestBody PushActive pushActive) {
         member.getMemberSetting().setLikePushActive(pushActive.isPushActive());
-        return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(
+        return ResponseEntity.ok(ApiResult.ok(memberDtoService.toDto(
                 memberService.updateMember(member)
         )));
     }
@@ -39,7 +41,7 @@ public class MemberSettingController {
                                                                      @ApiParam(value = "Push 설정 여부", required = true)
                                                                      @RequestBody PushActive pushActive) {
         member.getMemberSetting().setDailyPushActive(pushActive.isPushActive());
-        return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(
+        return ResponseEntity.ok(ApiResult.ok(memberDtoService.toDto(
                 memberService.updateMember(member)
         )));
     }

--- a/ink-core/src/main/java/net/ink/core/badge/service/BadgeAccomplishedServiceImpl.java
+++ b/ink-core/src/main/java/net/ink/core/badge/service/BadgeAccomplishedServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import net.ink.core.badge.entity.BadgeAccomplished;
 import net.ink.core.badge.entity.BadgeAccomplishedPK;
 import net.ink.core.badge.repository.BadgeAccomplishedRepository;
+import net.ink.core.cookie.repository.CookieAcquirementRepository;
 import net.ink.core.core.exception.BadRequestException;
 import net.ink.core.member.repository.MemberRepository;
 import net.ink.core.member.repository.MemberScrapRepository;
@@ -26,11 +27,13 @@ public class BadgeAccomplishedServiceImpl implements BadgeAccomplishedService {
     private final BadgeAccomplishedRepository badgeAccomplishedRepository;
     private final MemberScrapRepository memberScrapRepository;
     private final MemberRepository memberRepository;
+    private final CookieAcquirementRepository cookieAcquirementRepository;
 
 
     @Transactional
     public boolean createInk3Days(Long memberId) {
-        if ( memberRepository.findById(memberId).get().getInkCookies().size() == Ink3Days.conditionOfCount &&
+        long inkCount = cookieAcquirementRepository.countByMemberMemberId(memberId);
+        if ( inkCount == Ink3Days.conditionOfCount &&
                 !badgeAccomplishedRepository.existsBadgeAccomplishedByMemberMemberIdAndBadgeBadgeId(memberId, Ink3Days.id) ){
 
             badgeAccomplishedRepository.saveAndFlush(makeBadgeAccomplished(memberId, Ink3Days.id));
@@ -69,7 +72,8 @@ public class BadgeAccomplishedServiceImpl implements BadgeAccomplishedService {
 
     @Transactional
     public boolean createInkSet(Long memberId){
-        if ( memberRepository.findById(memberId).get().getInkCookies().size() == InkSet.conditionOfCount &&
+        long inkCount = cookieAcquirementRepository.countByMemberMemberId(memberId);
+        if ( inkCount == InkSet.conditionOfCount &&
                 !badgeAccomplishedRepository.existsBadgeAccomplishedByMemberMemberIdAndBadgeBadgeId(memberId, InkSet.id) ){
 
             badgeAccomplishedRepository.saveAndFlush(makeBadgeAccomplished(memberId, InkSet.id));

--- a/ink-core/src/main/java/net/ink/core/cookie/repository/CookieAcquirementRepository.java
+++ b/ink-core/src/main/java/net/ink/core/cookie/repository/CookieAcquirementRepository.java
@@ -7,4 +7,6 @@ import java.time.LocalDate;
 
 public interface CookieAcquirementRepository extends JpaRepository<CookieAcquirement, Long> {
     boolean existsByRegDateAndMemberMemberId(LocalDate date, Long memberId);
+    
+    long countByMemberMemberId(Long memberId);
 }

--- a/ink-core/src/main/java/net/ink/core/member/entity/Member.java
+++ b/ink-core/src/main/java/net/ink/core/member/entity/Member.java
@@ -75,7 +75,7 @@ public class Member {
     private LocalDateTime modDate = LocalDateTime.now();
 
     @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<CookieAcquirement> inkCookies = new HashSet<>();
 
     @Embedded


### PR DESCRIPTION
## 오류 수정

**문제 설명:**
치명적: EAGER Fetching으로 인한 N+1 문제 ink-core/src/main/java/net/ink/core/member/entity/Member.java:78 - inkCookies 컬렉션이 EAGER로 로딩되어 모든 Member 조회시 관련 데이터를 즉시 로딩 - 이 문제를 해결해줘

**수정 내용:**
테스트 실행을 승인해주세요. 그동안 변경사항을 요약하겠습니다.

## 오류의 근본 원인 분석

1. **N+1 쿼리 문제**: `Member` 엔티티의 `inkCookies` 컬렉션이 `FetchType.EAGER`로 설정되어 있어, Member를 조회할 때마다 관련된 모든 `CookieAcquirement` 데이터를 즉시 로딩했습니다.
2. **성능 영향**: 여러 Member를 조회하는 경우(예: `findAll()`, `findAllByIsActive()`) 각 Member마다 추가 쿼리가 실행되어 N+1 문제가 발생했습니다.

## 수행된 변경사항

### 1. Member 엔티티 수정
- `ink-core/src/main/java/net/ink/core/member/entity/Member.java:78`
- `FetchType.EAGER`를 `FetchType.LAZY`로 변경

### 2. CookieAcquirementRepository 개선
- `countByMemb...

---
*이 PR은 Discord Bot을 통해 자동으로 생성되었습니다.*
