### PR TITLE
카카오 이메일 충돌 이슈 / 답변 삭제 403 이슈

### DIFF
--- a/ink-api/src/main/java/net/ink/api/core/oauth2/dto/OAuth2Profile.java
+++ b/ink-api/src/main/java/net/ink/api/core/oauth2/dto/OAuth2Profile.java
@@ -12,4 +12,7 @@ import lombok.*;
 public class OAuth2Profile {
     @ApiModelProperty(value = "사용자 id")
     private String identifier;
+
+    @ApiModelProperty(value = "사용자 이메일")
+    private String email;
 }

--- a/ink-api/src/main/java/net/ink/api/core/oauth2/service/OAuth2Service.java
+++ b/ink-api/src/main/java/net/ink/api/core/oauth2/service/OAuth2Service.java
@@ -68,20 +68,26 @@ public class OAuth2Service {
 
     public OAuth2Profile setKakaoProfile(JsonNode jsonNode) {
         long identifier = jsonNode.get("id").asLong();
+        String email = null;
+        JsonNode kakaoAccount = jsonNode.get("kakao_account");
+        if (kakaoAccount != null && kakaoAccount.has("email")) {
+            email = kakaoAccount.get("email").asText(null);
+        }
 
-        return new OAuth2Profile("kakao_" + identifier);
+        return new OAuth2Profile("kakao_" + identifier, email);
     }
 
     public OAuth2Profile setGoogleProfile(JsonNode jsonNode){
         long identifier = jsonNode.get("localId").asLong();
+        String email = jsonNode.has("email") ? jsonNode.get("email").asText(null) : null;
 
-        return new OAuth2Profile("google_" + identifier);
+        return new OAuth2Profile("google_" + identifier, email);
     }
 
     public OAuth2Profile setAppleProfile(TokenDto.Provider token){
         // Apple의 경우 JWT의 sub가 identifier
         String identifier = jwtResolver.getUserIdentifier(token.getProviderAccessToken());
 
-        return new OAuth2Profile("apple_" + identifier);
+        return new OAuth2Profile("apple_" + identifier, null);
     }
 }

--- a/ink-api/src/main/java/net/ink/api/member/web/MemberAuthController.java
+++ b/ink-api/src/main/java/net/ink/api/member/web/MemberAuthController.java
@@ -38,8 +38,12 @@ public class MemberAuthController {
     public ResponseEntity<ApiResult<UserCheckDto>> userExists(
             @ApiParam(value = "액세스 토큰", required = true) @RequestBody @Valid TokenDto.Provider providerToken) {
         OAuth2Profile profile = oAuth2Service.getProfile(providerToken);
+        boolean exist = memberService.isMemberExist(profile.getIdentifier());
+        boolean emailConflict = !exist
+                && profile.getEmail() != null
+                && memberService.isEmailDuplicated(profile.getEmail());
         return ResponseEntity.ok(ApiResult.ok(
-                new UserCheckDto(memberService.isMemberExist(profile.getIdentifier()), profile.getIdentifier())
+                new UserCheckDto(exist || emailConflict, profile.getIdentifier(), emailConflict)
         ));
     }
 
@@ -65,5 +69,6 @@ public class MemberAuthController {
     public static class UserCheckDto {
         private final boolean exist;
         private final String identifier;
+        private final boolean emailConflict;
     }
 }

--- a/ink-api/src/test/java/net/ink/api/member/web/MemberAuthControllerTest.java
+++ b/ink-api/src/test/java/net/ink/api/member/web/MemberAuthControllerTest.java
@@ -36,7 +36,7 @@ class MemberAuthControllerTest extends AbstractControllerTest {
     @Test
     void 사용자_존재체크_테스트() throws Exception {
         TokenDto.Provider provider = new TokenDto.Provider(TokenProvider.KAKAO, TEST_PROVIDER_ACCESS_TOKEN);
-        when(oAuth2Service.getProfile(eq(provider))).thenReturn(new OAuth2Profile(TEST_IDENTIFIER));
+        when(oAuth2Service.getProfile(eq(provider))).thenReturn(new OAuth2Profile(TEST_IDENTIFIER, null));
 
         mockMvc.perform(
                 post("/api/member/user-exists")

--- a/ink-api/src/test/java/net/ink/api/oauth/OAuthTest.java
+++ b/ink-api/src/test/java/net/ink/api/oauth/OAuthTest.java
@@ -34,7 +34,7 @@ public class OAuthTest extends AbstractControllerTest {
     @Test
     public void 액세스토큰과_일치하는_사용자체크() throws Exception {
         TokenDto.Provider providerToken = new TokenDto.Provider(TokenProvider.GOOGLE, "testToken");
-        given(oAuth2Service.getProfile(eq(providerToken))).willReturn(new OAuth2Profile("test"));
+        given(oAuth2Service.getProfile(eq(providerToken))).willReturn(new OAuth2Profile("test", null));
         given(memberService.isMemberExist(eq("test"))).willReturn(true);
 
         mockMvc.perform(

--- a/ink-core/src/main/java/net/ink/core/reply/entity/Reply.java
+++ b/ink-core/src/main/java/net/ink/core/reply/entity/Reply.java
@@ -82,7 +82,7 @@ public class Reply {
     }
 
     public boolean isAuthor(Member member) {
-        return this.author.getMemberId() == member.getMemberId();
+        return this.author.getMemberId().equals(member.getMemberId());
     }
 
     public boolean likedByRequester(Member member) {


### PR DESCRIPTION
## 작업 내용 설명
- 카카오 로그인 이메일 중복 불일치 수정
-  본인 글 삭제/수정 시 403 오류 수정

## 주요 변경 사항
- OAuth2Profile에 email 필드 추가 및 Kakao/Google profile 비교
- Reply.isAuthor Long 타입 == 비교를 equals로 수정

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #

@NaRDo627 @jincastle
